### PR TITLE
add configs.inline property to pass complete config files

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -113,14 +113,22 @@ stages:
         int-file: 123123
       mountpath: /secrets
     configs:
+      # these are local files with golang template style placeholders, replaced with the values specified in the data section; 
+      # set clone: true on the release target to ensure you have access to these files stored in your repository
       files:
       - config/config.json
       - config/anotherconfig.yaml
+      # these are the values for the placeholders specified as {{.property1}} to be replaced in the config files
       data:
         property1: value 1
         property2: value 2
         property4: true
         property5: 123123
+      # if you want to avoid cloning your repository and just need to pass a very short config you can inline full files here
+      inline:
+        inline-config.properties: |
+          enemies=aliens
+          lives=3
       mountpath: /configs
     volumemounts:
     - name: client-certs

--- a/params.go
+++ b/params.go
@@ -128,6 +128,7 @@ type SecretsParams struct {
 type ConfigsParams struct {
 	Files               []string               `json:"files,omitempty"`
 	Data                map[string]interface{} `json:"data,omitempty"`
+	InlineFiles         map[string]string      `json:"inline,omitempty"`
 	MountPath           string                 `json:"mountpath,omitempty"`
 	RenderedFileContent map[string]string      `json:"-"`
 }

--- a/templateBuilder.go
+++ b/templateBuilder.go
@@ -112,9 +112,10 @@ func renderConfig(params Params) (renderedConfigFiles map[string]string) {
 
 	renderedConfigFiles = map[string]string{}
 
-	if params.Action != "rollback-canary" && len(params.Configs.Files) > 0 {
+	if params.Action != "rollback-canary" && (len(params.Configs.Files) > 0 || len(params.Configs.InlineFiles) > 0) {
 		logInfo("Prerendering config files...")
 
+		// render files passed with configs.files property, replacing placeholders with values specified in configs.data property
 		for _, cf := range params.Configs.Files {
 
 			data, err := ioutil.ReadFile(cf)
@@ -133,6 +134,11 @@ func renderConfig(params Params) (renderedConfigFiles map[string]string) {
 			}
 
 			renderedConfigFiles[filepath.Base(cf)] = renderedTemplate.String()
+		}
+
+		// add files passed with configs.inline property as is
+		for filename, content := range params.Configs.InlineFiles {
+			renderedConfigFiles[filename] = content
 		}
 	}
 


### PR DESCRIPTION
With this addition you don't need to store config file templates in your repository, but you can pass full files to the gke extension without cloning your repository during release.