### PR TITLE
Introduce a flag to control injecting the default HTTP proxy

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -102,7 +102,31 @@ stages:
       lifecycle:
         prestopsleep: true
         prestopsleepseconds: 15
-    injecthttpproxysidecar: false
+    sidecar:
+      type: openresty
+      image: estafette/openresty-sidecar:1.13.6.1-alpine
+      healthcheckpath: /readiness
+      env:
+        CORS_ALLOWED_ORIGINS: "*"
+        CORS_MAX_AGE: "86400"
+        MY_BOOL_ENV: true
+        MY_INT_ENV: 123123
+      cpu:
+        request: 10m
+        limit: 50m
+      memory:
+        request: 10Mi
+        limit: 50Mi
+    sidecars:
+    - type: cloudsqlproxy
+      dbinstanceconnectionname: my-gcloud-project:europe-west1:my-database
+      sqlproxyport: 5043
+      cpu:
+        request: 10m
+        limit: 50m
+      memory:
+        request: 10Mi
+        limit: 50Mi
     autoscale:
       min: 3
       max: 50

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -102,6 +102,7 @@ stages:
       lifecycle:
         prestopsleep: true
         prestopsleepseconds: 15
+    injecthttpproxysidecar: false
     autoscale:
       min: 3
       max: 50

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -102,31 +102,6 @@ stages:
       lifecycle:
         prestopsleep: true
         prestopsleepseconds: 15
-    sidecar:
-      type: openresty
-      image: estafette/openresty-sidecar:1.13.6.1-alpine
-      healthcheckpath: /readiness
-      env:
-        CORS_ALLOWED_ORIGINS: "*"
-        CORS_MAX_AGE: "86400"
-        MY_BOOL_ENV: true
-        MY_INT_ENV: 123123
-      cpu:
-        request: 10m
-        limit: 50m
-      memory:
-        request: 10Mi
-        limit: 50Mi
-    sidecars:
-    - type: cloudsqlproxy
-      dbinstanceconnectionname: my-gcloud-project:europe-west1:my-database
-      sqlproxyport: 5043
-      cpu:
-        request: 10m
-        limit: 50m
-      memory:
-        request: 10Mi
-        limit: 50Mi
     autoscale:
       min: 3
       max: 50

--- a/params.go
+++ b/params.go
@@ -343,7 +343,8 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 	}
 
 	if p.InjectHTTPProxySidecar == nil {
-		*p.InjectHTTPProxySidecar = true
+		trueValue := true
+		p.InjectHTTPProxySidecar = &trueValue
 	}
 
 	// Code for backwards-compatibility: in the parameters the sidecar can be specified both in the "sidecar" field, and also as an element in the "sidecars" collection.

--- a/params.go
+++ b/params.go
@@ -37,10 +37,11 @@ type Params struct {
 	UseGoogleCloudCredentials bool `json:"useGoogleCloudCredentials,omitempty"`
 
 	// container params
-	Container     ContainerParams     `json:"container,omitempty"`
-	Sidecar       SidecarParams       `json:"sidecar,omitempty"`
-	Sidecars      []SidecarParams     `json:"sidecars,omitempty"`
-	RollingUpdate RollingUpdateParams `json:"rollingupdate,omitempty"`
+	Container              ContainerParams     `json:"container,omitempty"`
+	InjectHTTPProxySidecar *bool               `json:"injecthttpproxysidecar,omitempty"`
+	Sidecar                SidecarParams       `json:"sidecar,omitempty"`
+	Sidecars               []SidecarParams     `json:"sidecars,omitempty"`
+	RollingUpdate          RollingUpdateParams `json:"rollingupdate,omitempty"`
 }
 
 // ContainerParams defines the container image to deploy
@@ -341,6 +342,10 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 		p.Container.Lifecycle.PrestopSleepSeconds = &defaultSleepValue
 	}
 
+	if p.InjectHTTPProxySidecar == nil {
+		*p.InjectHTTPProxySidecar = true
+	}
+
 	// Code for backwards-compatibility: in the parameters the sidecar can be specified both in the "sidecar" field, and also as an element in the "sidecars" collection.
 	// The "sidecar" field is kept around for backwards compatibility, but due to this we need some extra checks to cover all cases.
 	legacyOpenrestySidecarSpecified := p.Sidecar.Type == "openresty"
@@ -352,8 +357,8 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 		}
 	}
 
-	// If the openresty sidecar is not specified either in the "sidecar" field, nor in the "sidecars" collection (and this is not a Job), we add it to the list.
-	if !legacyOpenrestySidecarSpecified && !openrestySidecarSpecifiedInList && p.Kind != "job" {
+	// If the openresty sidecar is not specified either in the "sidecar" field, nor in the "sidecars" collection (and this is not a Job), and injecting the proxy is not explicitly disabled, we inject one by default.
+	if *p.InjectHTTPProxySidecar && !legacyOpenrestySidecarSpecified && !openrestySidecarSpecifiedInList && p.Kind != "job" {
 		openrestySidecar := SidecarParams{Type: "openresty"}
 
 		p.initializeSidecarDefaults(&openrestySidecar)

--- a/params_test.go
+++ b/params_test.go
@@ -1183,6 +1183,23 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, "openresty", params.Sidecars[0].Type)
 	})
 
+	t.Run("DoesntAddDefaultSidecarIfInjectFlagFalsEvenIfNoSidecarSpecified", func(t *testing.T) {
+
+		falseValue := false
+		params := Params{
+			Kind: "deployment",
+			InjectHTTPProxySidecar: &falseValue,
+			Sidecar: SidecarParams{
+				Type: "",
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, 0, len(params.Sidecars))
+	})
+
 	t.Run("AddsNoDefaultSidecarIfEmptyAndGlobalKindIsJob", func(t *testing.T) {
 
 		params := Params{

--- a/params_test.go
+++ b/params_test.go
@@ -1183,7 +1183,7 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, "openresty", params.Sidecars[0].Type)
 	})
 
-	t.Run("DoesntAddDefaultSidecarIfInjectFlagFalsEvenIfNoSidecarSpecified", func(t *testing.T) {
+	t.Run("DoesntAddDefaultSidecarIfInjectFlagIsFalseEvenIfNoSidecarSpecified", func(t *testing.T) {
 
 		falseValue := false
 		params := Params{


### PR DESCRIPTION
By introducing the `sidecars` array in #5, we need another way to create deployments which don't have the default openresty sidecar injected, so we're introducing a specific flag for this purpose.