### PR TITLE
Allow none sidecar

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -48,6 +48,50 @@ stages:
     copy:
     - templates
 
+  deploy-acceptance-rwd:
+    dryrun: true
+    image: extensions/gke:0.1.282
+    credentials: gke-development
+    namespace: frontend-acceptance
+    visibility: private
+    app: ${ESTAFETTE_BUILD_VERSION_LABEL}-rwd
+    injecthttpproxysidecar: false
+    volumemounts:
+    - name: ssl-certificate-rwd
+      mountpath: /etc/ssl
+      volume:
+        secret:
+          secretName: ${ESTAFETTE_BUILD_VERSION_LABEL}-rwd-letsencrypt-certificate
+    container:
+      name: "${ESTAFETTE_LABEL_APP}-rwd"
+      port: 80
+      additionalports:
+       - name: https
+         port: 443
+         protocol: TCP
+         visibility: duplicated
+       - name: metrics
+         port: 9090
+         protocol: TCP
+      env:
+        FE_SERVER_PERCENTAGE: 100
+        FE_SERVER_URL: https://${ESTAFETTE_BUILD_VERSION_LABEL}-fe-server
+      cpu:
+        request: 200m
+        limit: 1000m
+      memory:
+        request: 64Mi
+        limit: 256Mi
+      readiness:
+        path: /health_check
+      liveness:
+        path: /health_check
+      metrics:
+        scrape: false
+    when: status == 'succeeded' && branch != 'master'
+    hosts:
+      - ${ESTAFETTE_BUILD_VERSION_LABEL}-acceptance.cheaptickets.nl
+
   test-alpha-version:
     image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
     credentials: gke-tooling

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -51,11 +51,13 @@ stages:
   deploy-acceptance-rwd:
     dryrun: true
     image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-    credentials: gke-tooling
+    credentials: gke-development
     namespace: frontend-acceptance
     visibility: private
     app: ${ESTAFETTE_BUILD_VERSION_LABEL}-rwd
     injecthttpproxysidecar: false
+    sidecars:
+    - type: none
     volumemounts:
     - name: ssl-certificate-rwd
       mountpath: /etc/ssl

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -51,7 +51,7 @@ stages:
   deploy-acceptance-rwd:
     dryrun: true
     image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-    credentials: gke-development
+    credentials: gke-tooling
     namespace: frontend-acceptance
     visibility: private
     app: ${ESTAFETTE_BUILD_VERSION_LABEL}-rwd
@@ -94,7 +94,7 @@ stages:
 
   test-alpha-version:
     image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-    credentials: gke-tooling
+    credentials: gke-development
     action: deploy-simple
     kind: deployment
     app: gke

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -50,7 +50,7 @@ stages:
 
   deploy-acceptance-rwd:
     dryrun: true
-    image: extensions/gke:0.1.282
+    image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
     credentials: gke-development
     namespace: frontend-acceptance
     visibility: private

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -48,59 +48,12 @@ stages:
     copy:
     - templates
 
-  deploy-acceptance-rwd:
-    dryrun: true
-    image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-    credentials: gke-development
-    namespace: frontend-acceptance
-    visibility: private
-    app: ${ESTAFETTE_BUILD_VERSION_LABEL}-rwd
-    injecthttpproxysidecar: false
-    sidecars:
-    - type: none
-    volumemounts:
-    - name: ssl-certificate-rwd
-      mountpath: /etc/ssl
-      volume:
-        secret:
-          secretName: ${ESTAFETTE_BUILD_VERSION_LABEL}-rwd-letsencrypt-certificate
-    container:
-      name: "${ESTAFETTE_LABEL_APP}-rwd"
-      port: 80
-      additionalports:
-       - name: https
-         port: 443
-         protocol: TCP
-         visibility: duplicated
-       - name: metrics
-         port: 9090
-         protocol: TCP
-      env:
-        FE_SERVER_PERCENTAGE: 100
-        FE_SERVER_URL: https://${ESTAFETTE_BUILD_VERSION_LABEL}-fe-server
-      cpu:
-        request: 200m
-        limit: 1000m
-      memory:
-        request: 64Mi
-        limit: 256Mi
-      readiness:
-        path: /health_check
-      liveness:
-        path: /health_check
-      metrics:
-        scrape: false
-    when: status == 'succeeded' && branch != 'master'
-    hosts:
-      - ${ESTAFETTE_BUILD_VERSION_LABEL}-acceptance.cheaptickets.nl
-
   test-alpha-version:
     image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-    credentials: gke-development
+    credentials: gke-tooling
     action: deploy-simple
     kind: deployment
     app: gke
-    injecthttpproxysidecar: false
     namespace: estafette
     visibility: public-whitelist
     whitelist:
@@ -149,6 +102,31 @@ stages:
       lifecycle:
         prestopsleep: true
         prestopsleepseconds: 15
+    sidecar:
+      type: openresty
+      image: estafette/openresty-sidecar:1.13.6.1-alpine
+      healthcheckpath: /readiness
+      env:
+        CORS_ALLOWED_ORIGINS: "*"
+        CORS_MAX_AGE: "86400"
+        MY_BOOL_ENV: true
+        MY_INT_ENV: 123123
+      cpu:
+        request: 10m
+        limit: 50m
+      memory:
+        request: 10Mi
+        limit: 50Mi
+    sidecars:
+    - type: cloudsqlproxy
+      dbinstanceconnectionname: my-gcloud-project:europe-west1:my-database
+      sqlproxyport: 5043
+      cpu:
+        request: 10m
+        limit: 50m
+      memory:
+        request: 10Mi
+        limit: 50Mi
     autoscale:
       min: 3
       max: 50

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -98,6 +98,7 @@ stages:
     action: deploy-simple
     kind: deployment
     app: gke
+    injecthttpproxysidecar: false
     namespace: estafette
     visibility: public-whitelist
     whitelist:

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -146,31 +146,6 @@ stages:
       lifecycle:
         prestopsleep: true
         prestopsleepseconds: 15
-    sidecar:
-      type: openresty
-      image: estafette/openresty-sidecar:1.13.6.1-alpine
-      healthcheckpath: /readiness
-      env:
-        CORS_ALLOWED_ORIGINS: "*"
-        CORS_MAX_AGE: "86400"
-        MY_BOOL_ENV: true
-        MY_INT_ENV: 123123
-      cpu:
-        request: 10m
-        limit: 50m
-      memory:
-        request: 10Mi
-        limit: 50Mi
-    sidecars:
-    - type: cloudsqlproxy
-      dbinstanceconnectionname: my-gcloud-project:europe-west1:my-database
-      sqlproxyport: 5043
-      cpu:
-        request: 10m
-        limit: 50m
-      memory:
-        request: 10Mi
-        limit: 50Mi
     autoscale:
       min: 3
       max: 50

--- a/params.go
+++ b/params.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 )
@@ -344,12 +343,9 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 	}
 
 	if p.InjectHTTPProxySidecar == nil {
-		log.Printf("p.InjectHTTPProxySidecar was nil, setting it to true")
 		trueValue := true
 		p.InjectHTTPProxySidecar = &trueValue
 	}
-
-	log.Printf("p.InjectHTTPProxySidecar: %v", *p.InjectHTTPProxySidecar)
 
 	// Code for backwards-compatibility: in the parameters the sidecar can be specified both in the "sidecar" field, and also as an element in the "sidecars" collection.
 	// The "sidecar" field is kept around for backwards compatibility, but due to this we need some extra checks to cover all cases.
@@ -362,10 +358,8 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 		}
 	}
 
-	log.Printf("*p.InjectHTTPProxySidecar: %v, legacyOpenrestySidecarSpecified: %v, openrestySidecarSpecifiedInList: %v", *p.InjectHTTPProxySidecar, legacyOpenrestySidecarSpecified, openrestySidecarSpecifiedInList)
 	// If the openresty sidecar is not specified either in the "sidecar" field, nor in the "sidecars" collection (and this is not a Job), and injecting the proxy is not explicitly disabled, we inject one by default.
 	if *p.InjectHTTPProxySidecar && !legacyOpenrestySidecarSpecified && !openrestySidecarSpecifiedInList && p.Kind != "job" {
-		log.Printf("Injecting the default openresty sidecar")
 		openrestySidecar := SidecarParams{Type: "openresty"}
 
 		p.initializeSidecarDefaults(&openrestySidecar)

--- a/params.go
+++ b/params.go
@@ -652,6 +652,8 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 
 func (p *Params) validateSidecar(sidecar SidecarParams, errors []error) []error {
 	switch sidecar.Type {
+	case "none":
+		break
 	case "openresty":
 		break
 	case "cloudsqlproxy":

--- a/params.go
+++ b/params.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 )
@@ -343,9 +344,12 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 	}
 
 	if p.InjectHTTPProxySidecar == nil {
+		log.Printf("p.InjectHTTPProxySidecar was nil, setting it to true")
 		trueValue := true
 		p.InjectHTTPProxySidecar = &trueValue
 	}
+
+	log.Printf("p.InjectHTTPProxySidecar: %v", *p.InjectHTTPProxySidecar)
 
 	// Code for backwards-compatibility: in the parameters the sidecar can be specified both in the "sidecar" field, and also as an element in the "sidecars" collection.
 	// The "sidecar" field is kept around for backwards compatibility, but due to this we need some extra checks to cover all cases.
@@ -358,8 +362,10 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 		}
 	}
 
+	log.Printf("*p.InjectHTTPProxySidecar: %v, legacyOpenrestySidecarSpecified: %v, openrestySidecarSpecifiedInList: %v", *p.InjectHTTPProxySidecar, legacyOpenrestySidecarSpecified, openrestySidecarSpecifiedInList)
 	// If the openresty sidecar is not specified either in the "sidecar" field, nor in the "sidecars" collection (and this is not a Job), and injecting the proxy is not explicitly disabled, we inject one by default.
 	if *p.InjectHTTPProxySidecar && !legacyOpenrestySidecarSpecified && !openrestySidecarSpecifiedInList && p.Kind != "job" {
+		log.Printf("Injecting the default openresty sidecar")
 		openrestySidecar := SidecarParams{Type: "openresty"}
 
 		p.initializeSidecarDefaults(&openrestySidecar)


### PR DESCRIPTION
This is needed for now, because what happens is the following:

- Someone doesn't want to use a sidecar, so they add `injecthttpproxysidecar: false` to their manifest, and leave the `sidecars` array empty (so they don't even add it to the manifest).
- But in the `estafette-ci-api` we configure openresty as a default element of the `sidecars` collection, which gets applied to our params.
- And in the code, even though `InjectHTTPProxySidecar` is `false`, there is an explicit `openresty` sidecar in the list, so we end up using that.

To work around this, we allow the sidecar type to be `none`, so in the manifest we can say

```
injecthttpproxysidecar: false
sidecars:
- type none
```

This way the default openresty coming from the `estafette-ci-api` config won't be applied to our params.