### PR TITLE
Set hpa scaler annotation via params

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -131,6 +131,12 @@ stages:
       min: 3
       max: 50
       cpu: 80
+      safety:
+        enabled: true
+        promquery: "sum(rate(nginx_http_requests_total{app='my-app'}[5m])) by (app)"
+        ratio: 2.5
+        delta: -0.5
+        scaledownratio: 0.2
     request:
       timeout: 60s
       maxbodysize: 128m

--- a/params_test.go
+++ b/params_test.go
@@ -660,6 +660,132 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, 30, params.Autoscale.CPUPercentage)
 	})
 
+	t.Run("DefaultsAutoscaleSafetyEnabledToFalse", func(t *testing.T) {
+
+		params := Params{
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.False(t, params.Autoscale.Safety.Enabled)
+	})
+
+	t.Run("KeepsAutoscaleSafetyEnabled", func(t *testing.T) {
+
+		params := Params{
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					Enabled: true,
+				},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.True(t, params.Autoscale.Safety.Enabled)
+	})
+
+	t.Run("DefaultsAutoscaleSafetyPromQueryToRequestRateForAppLabelOverLast5Minutes", func(t *testing.T) {
+
+		params := Params{
+			App: "my-app",
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, "sum(rate(nginx_http_requests_total{app='my-app'}[5m])) by (app)", params.Autoscale.Safety.PromQuery)
+	})
+
+	t.Run("KeepsAutoscaleSafetyPromQuery", func(t *testing.T) {
+
+		params := Params{
+			App: "my-app",
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					PromQuery: "sum(rate(nginx_http_requests_total{app='your-app'}[5m])) by (app)",
+				},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, "sum(rate(nginx_http_requests_total{app='your-app'}[5m])) by (app)", params.Autoscale.Safety.PromQuery)
+	})
+
+	t.Run("DefaultsAutoscaleSafetyRatioToOne", func(t *testing.T) {
+
+		params := Params{
+			App: "my-app",
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, 1.0, params.Autoscale.Safety.Ratio)
+	})
+
+	t.Run("KeepsAutoscaleSafetyRatio", func(t *testing.T) {
+
+		params := Params{
+			App: "my-app",
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					Ratio: 1.5,
+				},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, 1.5, params.Autoscale.Safety.Ratio)
+	})
+
+	t.Run("DefaultsAutoscaleSafetyScaleDownRatioToOne", func(t *testing.T) {
+
+		params := Params{
+			App: "my-app",
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, 1.0, params.Autoscale.Safety.ScaleDownRatio)
+	})
+
+	t.Run("KeepsAutoscaleSafetyScaleDownRatio", func(t *testing.T) {
+
+		params := Params{
+			App: "my-app",
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					ScaleDownRatio: 0.2,
+				},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, 0.2, params.Autoscale.Safety.ScaleDownRatio)
+	})
+
 	t.Run("DefaultsRequestTimeoutTo60sIfEmpty", func(t *testing.T) {
 
 		params := Params{
@@ -1187,7 +1313,7 @@ func TestSetDefaults(t *testing.T) {
 
 		falseValue := false
 		params := Params{
-			Kind: "deployment",
+			Kind:                   "deployment",
 			InjectHTTPProxySidecar: &falseValue,
 			Sidecar: SidecarParams{
 				Type: "",

--- a/templateData.go
+++ b/templateData.go
@@ -23,6 +23,11 @@ type TemplateData struct {
 	MinReplicas                      int
 	MaxReplicas                      int
 	TargetCPUPercentage              int
+	UseHpaScaler                     bool
+	HpaScalerPromQuery               string
+	HpaScalerRequestsPerReplica      string
+	HpaScalerDelta                   string
+	HpaScalerScaleDownMaxRatio       string
 	PreferPreemptibles               bool
 	Container                        ContainerData
 	Sidecars                         []SidecarData

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -31,6 +32,12 @@ func generateTemplateData(params Params, currentReplicas int, releaseID string) 
 		MinReplicas:         params.Autoscale.MinReplicas,
 		MaxReplicas:         params.Autoscale.MaxReplicas,
 		TargetCPUPercentage: params.Autoscale.CPUPercentage,
+
+		UseHpaScaler:                params.Autoscale.Safety.Enabled,
+		HpaScalerPromQuery:          params.Autoscale.Safety.PromQuery,
+		HpaScalerRequestsPerReplica: fmt.Sprintf("%.3f", params.Autoscale.Safety.Ratio),
+		HpaScalerDelta:              fmt.Sprintf("%.3f", params.Autoscale.Safety.Delta),
+		HpaScalerScaleDownMaxRatio:  fmt.Sprintf("%.3f", params.Autoscale.Safety.ScaleDownRatio),
 
 		Secrets:                 params.Secrets.Keys,
 		MountApplicationSecrets: len(params.Secrets.Keys) > 0,

--- a/templateDataGenerator_test.go
+++ b/templateDataGenerator_test.go
@@ -1653,4 +1653,84 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		assert.Equal(t, "*/5 * * * *", templateData.Schedule)
 	})
+
+	t.Run("SetsUseHpaScalerToAutoscalerSafetyEnabledParam", func(t *testing.T) {
+
+		params := Params{
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					Enabled: true,
+				},
+			},
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "")
+
+		assert.True(t, templateData.UseHpaScaler)
+	})
+
+	t.Run("SetsHpaScalerPromQueryToAutoscalerSafetyPromQueryParam", func(t *testing.T) {
+
+		params := Params{
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					PromQuery: "sum(rate(nginx_http_requests_total{app='my-app'}[5m])) by (app)",
+				},
+			},
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "")
+
+		assert.Equal(t, "sum(rate(nginx_http_requests_total{app='my-app'}[5m])) by (app)", templateData.HpaScalerPromQuery)
+	})
+
+	t.Run("SetsHpaScalerRequestsPerReplicaToAutoscalerSafetyPromQueryParam", func(t *testing.T) {
+
+		params := Params{
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					Ratio: 0.25,
+				},
+			},
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "")
+
+		assert.Equal(t, "0.250", templateData.HpaScalerRequestsPerReplica)
+	})
+
+	t.Run("SetsHpaScalerRequestsPerReplicaToAutoscalerSafetyPromQueryParam", func(t *testing.T) {
+
+		params := Params{
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					Delta: -2.7584,
+				},
+			},
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "")
+
+		assert.Equal(t, "-2.758", templateData.HpaScalerDelta)
+	})
+
+	t.Run("SetsHpaScalerRequestsPerReplicaToAutoscalerSafetyPromQueryParam", func(t *testing.T) {
+
+		params := Params{
+			Autoscale: AutoscaleParams{
+				Safety: AutoscaleSafetyParams{
+					ScaleDownRatio: 0.2,
+				},
+			},
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "")
+
+		assert.Equal(t, "0.200", templateData.HpaScalerScaleDownMaxRatio)
+	})
 }

--- a/templates/horizontalpodautoscaler.yaml
+++ b/templates/horizontalpodautoscaler.yaml
@@ -7,6 +7,14 @@ metadata:
     {{- range $key, $value := .Labels}}
     {{$key}}: {{$value}}
     {{- end}}
+  {{- if .UseHpaScaler}}
+  annotations:
+    estafette.io/hpa-scaler: "true"
+    estafette.io/hpa-scaler-prometheus-query: "{{.HpaScalerPromQuery}}"
+    estafette.io/hpa-scaler-requests-per-replica: "{{.HpaScalerRequestsPerReplica}}"
+    estafette.io/hpa-scaler-delta: "{{.HpaScalerDelta}}"
+    estafette.io/hpa-scaler-scale-down-max-ratio: "{{.HpaScalerScaleDownMaxRatio}}"
+  {{- end}}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
This sets the estafette hpa-scaler annotations on the HorizontalPodAutoscaler if needed; disabled by default.