### PR TITLE
Use the custom application secrets to provide the service account key to the Cloud SQL Proxy

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -120,6 +120,7 @@ stages:
     sidecars:
     - type: cloudsqlproxy
       dbinstanceconnectionname: my-gcloud-project:europe-west1:my-database
+      serviceaccountkeyfilepath: /secrets/service-account-key.json
       sqlproxyport: 5043
       cpu:
         request: 10m
@@ -149,6 +150,7 @@ stages:
         secret-file-2.yaml: YW5vdGhlciBzZWNyZXQgdmFsdWU=
         bool-file: true
         int-file: 123123
+        service-account-key.json: "abc"
       mountpath: /secrets
     configs:
       # these are local files with golang template style placeholders, replaced with the values specified in the data section;

--- a/params.go
+++ b/params.go
@@ -131,14 +131,15 @@ type LifecycleParams struct {
 
 // SidecarParams sets params for sidecar injection
 type SidecarParams struct {
-	Type                     string                 `json:"type,omitempty"`
-	Image                    string                 `json:"image,omitempty"`
-	EnvironmentVariables     map[string]interface{} `json:"env,omitempty"`
-	CPU                      CPUParams              `json:"cpu,omitempty"`
-	Memory                   MemoryParams           `json:"memory,omitempty"`
-	HealthCheckPath          string                 `json:"healthcheckpath,omitempty"`
-	DbInstanceConnectionName string                 `json:"dbinstanceconnectionname,omitempty"`
-	SQLProxyPort             int                    `json:"sqlproxyport,omitempty"`
+	Type                      string                 `json:"type,omitempty"`
+	Image                     string                 `json:"image,omitempty"`
+	EnvironmentVariables      map[string]interface{} `json:"env,omitempty"`
+	CPU                       CPUParams              `json:"cpu,omitempty"`
+	Memory                    MemoryParams           `json:"memory,omitempty"`
+	HealthCheckPath           string                 `json:"healthcheckpath,omitempty"`
+	DbInstanceConnectionName  string                 `json:"dbinstanceconnectionname,omitempty"`
+	SQLProxyPort              int                    `json:"sqlproxyport,omitempty"`
+	ServiceAccountKeyFilePath string                 `json:"serviceaccountkeyfilepath,omitempty"`
 }
 
 // RollingUpdateParams sets params for controlling rolling update speed
@@ -674,6 +675,9 @@ func (p *Params) validateSidecar(sidecar SidecarParams, errors []error) []error 
 		}
 		if sidecar.SQLProxyPort == 0 {
 			errors = append(errors, fmt.Errorf("The port on which the Cloud SQL Proxy listens is required; set it via sidecar.sqlproxyport property on this stage"))
+		}
+		if sidecar.ServiceAccountKeyFilePath == "" {
+			errors = append(errors, fmt.Errorf("The path of the mounted service account key file is required; set it via sidecar.serviceaccountkeyfilepath property on this stage"))
 		}
 	default:
 		errors = append(errors, fmt.Errorf("The sidecar type is incorrect; allowed values are openresty or cloudsqlproxy"))

--- a/params_test.go
+++ b/params_test.go
@@ -1313,7 +1313,7 @@ func TestSetDefaults(t *testing.T) {
 
 		falseValue := false
 		params := Params{
-			Kind:                   "deployment",
+			Kind: "deployment",
 			InjectHTTPProxySidecar: &falseValue,
 			Sidecar: SidecarParams{
 				Type: "",
@@ -2937,6 +2937,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 		params.Sidecar.Type = "cloudsqlproxy"
 		params.Sidecar.DbInstanceConnectionName = ""
 		params.Sidecar.SQLProxyPort = 8080
+		params.Sidecar.ServiceAccountKeyFilePath = "/service-account.json"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()
@@ -2951,6 +2952,22 @@ func TestValidateRequiredProperties(t *testing.T) {
 		params.Sidecar.Type = "cloudsqlproxy"
 		params.Sidecar.DbInstanceConnectionName = "instance"
 		params.Sidecar.SQLProxyPort = 0
+		params.Sidecar.ServiceAccountKeyFilePath = "/service-account.json"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.False(t, valid)
+		assert.True(t, len(errors) == 1)
+	})
+
+	t.Run("ReturnsFalseIfServiceAccountKeyFilePathNotSet", func(t *testing.T) {
+
+		params := validParams
+		params.Sidecar.Type = "cloudsqlproxy"
+		params.Sidecar.DbInstanceConnectionName = "instance"
+		params.Sidecar.SQLProxyPort = 8080
+		params.Sidecar.ServiceAccountKeyFilePath = ""
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()
@@ -2965,6 +2982,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 		params.Sidecar.Type = "cloudsqlproxy"
 		params.Sidecar.DbInstanceConnectionName = "instance"
 		params.Sidecar.SQLProxyPort = 8080
+		params.Sidecar.ServiceAccountKeyFilePath = "/service-account.json"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -250,9 +250,10 @@ func buildSidecar(sidecar SidecarParams, request RequestParams) SidecarData {
 		MemoryLimit:          sidecar.Memory.Limit,
 		EnvironmentVariables: sidecar.EnvironmentVariables,
 		SidecarSpecificProperties: map[string]interface{}{
-			"healthcheckpath":          sidecar.HealthCheckPath,
-			"dbinstanceconnectionname": sidecar.DbInstanceConnectionName,
-			"sqlproxyport":             sidecar.SQLProxyPort,
+			"healthcheckpath":           sidecar.HealthCheckPath,
+			"dbinstanceconnectionname":  sidecar.DbInstanceConnectionName,
+			"sqlproxyport":              sidecar.SQLProxyPort,
+			"serviceaccountkeyfilepath": sidecar.ServiceAccountKeyFilePath,
 		},
 	}
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -220,13 +220,13 @@ spec:
         command: ["/cloud_sql_proxy",
                   "-instances={{ index .SidecarSpecificProperties "dbinstanceconnectionname" }}=tcp:{{ index .SidecarSpecificProperties "sqlproxyport" }}",
                   "-credential_file={{ index .SidecarSpecificProperties "serviceaccountkeyfilepath" }}"]
-        {{- if or .MountServiceAccountSecret .MountAdditionalVolumes }}
+        {{- if or $deployment.MountServiceAccountSecret $deployment.MountAdditionalVolumes }}
         volumeMounts:
         {{- if $deployment.MountServiceAccountSecret }}
         - name: gcp-service-account
           mountPath: /gcp-service-account
         {{- end }}
-        {{- range .AdditionalVolumeMounts}}
+        {{- range $deployment.AdditionalVolumeMounts}}
         - name: {{.Name}}
           mountPath: {{.MountPath}}
         {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -219,12 +219,17 @@ spec:
             memory: {{.MemoryLimit}}
         command: ["/cloud_sql_proxy",
                   "-instances={{ index .SidecarSpecificProperties "dbinstanceconnectionname" }}=tcp:{{ index .SidecarSpecificProperties "sqlproxyport" }}",
-                  "-credential_file=/gcp-service-account/service-account-key.json"]
-          {{- if $deployment.MountServiceAccountSecret }}
+                  "-credential_file={{ index .SidecarSpecificProperties "serviceaccountkeyfilepath" }}"]
+        {{- if or .MountServiceAccountSecret .MountAdditionalVolumes }}
         volumeMounts:
-          - name: gcp-service-account
-            mountPath: /gcp-service-account
-          {{- end }}
+        {{- if $deployment.MountServiceAccountSecret }}
+        - name: gcp-service-account
+          mountPath: /gcp-service-account
+        {{- end }}
+        {{- range .AdditionalVolumeMounts}}
+        - name: {{.Name}}
+          mountPath: {{.MountPath}}
+        {{- end }}
         {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: 300

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -228,7 +228,7 @@ spec:
         {{- end }}
         {{- if $deployment.MountApplicationSecrets }}
         - name: app-secrets
-          mountPath: {{.SecretMountPath}}
+          mountPath: {{$deployment.SecretMountPath}}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -220,15 +220,15 @@ spec:
         command: ["/cloud_sql_proxy",
                   "-instances={{ index .SidecarSpecificProperties "dbinstanceconnectionname" }}=tcp:{{ index .SidecarSpecificProperties "sqlproxyport" }}",
                   "-credential_file={{ index .SidecarSpecificProperties "serviceaccountkeyfilepath" }}"]
-        {{- if or $deployment.MountServiceAccountSecret $deployment.MountAdditionalVolumes }}
+        {{- if or $deployment.MountServiceAccountSecret $deployment.MountApplicationSecrets }}
         volumeMounts:
         {{- if $deployment.MountServiceAccountSecret }}
         - name: gcp-service-account
           mountPath: /gcp-service-account
         {{- end }}
-        {{- range $deployment.AdditionalVolumeMounts}}
-        - name: {{.Name}}
-          mountPath: {{.MountPath}}
+        {{- if $deployment.MountApplicationSecrets }}
+        - name: app-secrets
+          mountPath: {{.SecretMountPath}}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -231,6 +231,7 @@ spec:
           mountPath: {{.MountPath}}
         {{- end }}
         {{- end }}
+        {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: 300
       volumes:


### PR DESCRIPTION
Initially I wanted to use
```
useGoogleCloudCredentials: true
```
And just depend on the automatically mounted secret to have the service account key in the Cloud SQL Proxy.
Unfortunately this is not possible at the moment, becaus [the proxy doesn't handle key rotation](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/205).
So for the time being I changed the implementation so that the normal application secrets are mounted, thus in our `.estafette.yaml` we can provide the service account in a custom secret.
(And we can change this once they implement the handling of the key rotation in the proxy.)