### PR TITLE
allow key rotation for service account secret to be disabled

### DIFF
--- a/params.go
+++ b/params.go
@@ -33,8 +33,9 @@ type Params struct {
 	Configs        ConfigsParams       `json:"configs,omitempty"`
 	VolumeMounts   []VolumeMountParams `json:"volumemounts,omitempty"`
 
-	EnablePayloadLogging      bool `json:"enablePayloadLogging,omitempty"`
-	UseGoogleCloudCredentials bool `json:"useGoogleCloudCredentials,omitempty"`
+	EnablePayloadLogging             bool `json:"enablePayloadLogging,omitempty"`
+	UseGoogleCloudCredentials        bool `json:"useGoogleCloudCredentials,omitempty"`
+	DisableServiceAccountKeyRotation bool `json:"disableServiceAccountKeyRotation,omitempty"`
 
 	// container params
 	Container              ContainerParams     `json:"container,omitempty"`

--- a/templateData.go
+++ b/templateData.go
@@ -39,6 +39,7 @@ type TemplateData struct {
 	ConfigMountPath                  string
 	MountPayloadLogging              bool
 	MountServiceAccountSecret        bool
+	DisableServiceAccountKeyRotation bool
 	RollingUpdateMaxSurge            string
 	RollingUpdateMaxUnavailable      string
 	BuildVersion                     string

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -52,8 +52,9 @@ func generateTemplateData(params Params, currentReplicas int, releaseID, trigger
 		RollingUpdateMaxSurge:       params.RollingUpdate.MaxSurge,
 		RollingUpdateMaxUnavailable: params.RollingUpdate.MaxUnavailable,
 
-		PreferPreemptibles:        params.ChaosProof,
-		MountServiceAccountSecret: params.UseGoogleCloudCredentials,
+		PreferPreemptibles:               params.ChaosProof,
+		MountServiceAccountSecret:        params.UseGoogleCloudCredentials,
+		DisableServiceAccountKeyRotation: params.DisableServiceAccountKeyRotation,
 
 		Container: ContainerData{
 			Repository: params.Container.ImageRepository,

--- a/templates/service-account-secret.yaml
+++ b/templates/service-account-secret.yaml
@@ -11,4 +11,7 @@ metadata:
   annotations:
     estafette.io/gcp-service-account: 'true'
     estafette.io/gcp-service-account-name: '{{.Name}}'
+    {{- if .DisableServiceAccountKeyRotation}}
+    estafette.io/gcp-service-account-disable-key-rotation: 'true'
+    {{- end}}
 type: Opaque


### PR DESCRIPTION
This allows the new annotation for gcp-service-account to disable key rotation to be used.