### PR TITLE
 Enable customizing the CronJob concurrency policy

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -229,6 +229,7 @@ stages:
     credentials: gke-tooling
     kind: cronjob
     schedule: "*/5 * * * *"
+    concurrencypolicy: Forbid
     container:
       repository: extensions
     dryrun: true

--- a/params.go
+++ b/params.go
@@ -440,7 +440,9 @@ func (p *Params) SetDefaults(appLabel, buildVersion, releaseName, releaseAction 
 	}
 
 	if p.Kind == "cronjob" {
-		p.ConcurrencyPolicy = "Allow"
+		if p.ConcurrencyPolicy == "" {
+			p.ConcurrencyPolicy = "Allow"
+		}
 	}
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -1313,7 +1313,7 @@ func TestSetDefaults(t *testing.T) {
 
 		falseValue := false
 		params := Params{
-			Kind:                   "deployment",
+			Kind: "deployment",
 			InjectHTTPProxySidecar: &falseValue,
 			Sidecar: SidecarParams{
 				Type: "",
@@ -3104,6 +3104,7 @@ func TestValidateRequiredProperties(t *testing.T) {
 		params := validParams
 		params.Kind = "cronjob"
 		params.Schedule = ""
+		params.ConcurrencyPolicy = "Allow"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()
@@ -3112,11 +3113,26 @@ func TestValidateRequiredProperties(t *testing.T) {
 		assert.True(t, len(errors) > 0)
 	})
 
-	t.Run("ReturnsTrueIfScheduleIsSetAndKindIsCronjob", func(t *testing.T) {
+	t.Run("ReturnsFalseIfConcurrencyPolicyIsInvalidAndKindIsCronjob", func(t *testing.T) {
 
 		params := validParams
 		params.Kind = "cronjob"
 		params.Schedule = "*/5 * * * *"
+		params.ConcurrencyPolicy = "InvalidPolicy"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.False(t, valid)
+		assert.True(t, len(errors) > 0)
+	})
+
+	t.Run("ReturnsTrueIfScheduleIsSetAndConcurrencyPolicyIsValidAndKindIsCronjob", func(t *testing.T) {
+
+		params := validParams
+		params.Kind = "cronjob"
+		params.Schedule = "*/5 * * * *"
+		params.ConcurrencyPolicy = "Allow"
 
 		// act
 		valid, errors, _ := params.ValidateRequiredProperties()

--- a/params_test.go
+++ b/params_test.go
@@ -1966,6 +1966,19 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, "deployment", params.Kind)
 	})
 
+	t.Run("DefaultsToAllowConcurrencyPolicyForCronJobs", func(t *testing.T) {
+
+		params := Params{
+			Kind:              "cronjob",
+			ConcurrencyPolicy: "",
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", map[string]string{})
+
+		assert.Equal(t, "Allow", params.ConcurrencyPolicy)
+	})
+
 	t.Run("KeepsKindIfNotEmpty", func(t *testing.T) {
 
 		params := Params{

--- a/templateData.go
+++ b/templateData.go
@@ -6,6 +6,7 @@ type TemplateData struct {
 	NameWithTrack                    string
 	Namespace                        string
 	Schedule                         string
+	ConcurrencyPolicy                string
 	Labels                           map[string]string
 	AppLabelSelector                 string
 	Hosts                            []string

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -14,12 +14,13 @@ func generateTemplateData(params Params, currentReplicas int, releaseID, trigger
 	data := TemplateData{
 		BuildVersion: params.BuildVersion,
 
-		Name:             params.App,
-		NameWithTrack:    params.App,
-		Namespace:        params.Namespace,
-		Schedule:         params.Schedule,
-		Labels:           sanitizeLabels(params.Labels),
-		AppLabelSelector: sanitizeLabel(params.App),
+		Name:              params.App,
+		NameWithTrack:     params.App,
+		Namespace:         params.Namespace,
+		Schedule:          params.Schedule,
+		ConcurrencyPolicy: params.ConcurrencyPolicy,
+		Labels:            sanitizeLabels(params.Labels),
+		AppLabelSelector:  sanitizeLabel(params.App),
 
 		Hosts:               params.Hosts,
 		HostsJoined:         strings.Join(params.Hosts, ","),

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- end}}
 spec:
   schedule: '{{.Schedule}}'
-  concurrencyPolicy: Allow
+  concurrencyPolicy: {{.ConcurrencyPolicy}}
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
   suspend: false  


### PR DESCRIPTION
This PR enables customizing the value of the `concurrencyPolicy` field to either `Allow`, `Forbid` or `Replace`.