### PR TITLE
Add capability to customize the Cloud SQL Proxy termination timeout

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -119,6 +119,7 @@ stages:
     - type: cloudsqlproxy
       dbinstanceconnectionname: my-gcloud-project:europe-west1:my-database
       sqlproxyport: 5043
+      sqlproxyterminationtimeoutseconds: 30
       cpu:
         request: 10m
         limit: 50m

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -119,7 +119,6 @@ stages:
     - type: cloudsqlproxy
       dbinstanceconnectionname: my-gcloud-project:europe-west1:my-database
       sqlproxyport: 5043
-      sqlproxyterminationtimeoutseconds: 30
       cpu:
         request: 10m
         limit: 50m

--- a/params.go
+++ b/params.go
@@ -466,7 +466,7 @@ func (p *Params) initializeSidecarDefaults(sidecar *SidecarParams) {
 				sidecar.HealthCheckPath = p.Container.ReadinessProbe.Path
 			}
 		case "cloudsqlproxy":
-			sidecar.Image = "gcr.io/cloudsql-docker/gce-proxy:1.13"
+			sidecar.Image = "gcr.io/cloudsql-docker/gce-proxy:1.14"
 		}
 	}
 

--- a/params.go
+++ b/params.go
@@ -136,14 +136,15 @@ type LifecycleParams struct {
 
 // SidecarParams sets params for sidecar injection
 type SidecarParams struct {
-	Type                     string                 `json:"type,omitempty"`
-	Image                    string                 `json:"image,omitempty"`
-	EnvironmentVariables     map[string]interface{} `json:"env,omitempty"`
-	CPU                      CPUParams              `json:"cpu,omitempty"`
-	Memory                   MemoryParams           `json:"memory,omitempty"`
-	HealthCheckPath          string                 `json:"healthcheckpath,omitempty"`
-	DbInstanceConnectionName string                 `json:"dbinstanceconnectionname,omitempty"`
-	SQLProxyPort             int                    `json:"sqlproxyport,omitempty"`
+	Type                              string                 `json:"type,omitempty"`
+	Image                             string                 `json:"image,omitempty"`
+	EnvironmentVariables              map[string]interface{} `json:"env,omitempty"`
+	CPU                               CPUParams              `json:"cpu,omitempty"`
+	Memory                            MemoryParams           `json:"memory,omitempty"`
+	HealthCheckPath                   string                 `json:"healthcheckpath,omitempty"`
+	DbInstanceConnectionName          string                 `json:"dbinstanceconnectionname,omitempty"`
+	SQLProxyPort                      int                    `json:"sqlproxyport,omitempty"`
+	SQLProxyTerminationTimeoutSeconds int                    `json:"sqlproxyterminationtimeoutseconds,omitempty"`
 }
 
 // RollingUpdateParams sets params for controlling rolling update speed

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -279,9 +279,10 @@ func buildSidecar(sidecar SidecarParams, request RequestParams) SidecarData {
 		MemoryLimit:          sidecar.Memory.Limit,
 		EnvironmentVariables: sidecar.EnvironmentVariables,
 		SidecarSpecificProperties: map[string]interface{}{
-			"healthcheckpath":          sidecar.HealthCheckPath,
-			"dbinstanceconnectionname": sidecar.DbInstanceConnectionName,
-			"sqlproxyport":             sidecar.SQLProxyPort,
+			"healthcheckpath":                   sidecar.HealthCheckPath,
+			"dbinstanceconnectionname":          sidecar.DbInstanceConnectionName,
+			"sqlproxyport":                      sidecar.SQLProxyPort,
+			"sqlproxyterminationtimeoutseconds": sidecar.SQLProxyTerminationTimeoutSeconds,
 		},
 	}
 

--- a/templateDataGenerator_test.go
+++ b/templateDataGenerator_test.go
@@ -890,6 +890,27 @@ func TestGenerateTemplateData(t *testing.T) {
 		assert.Equal(t, "value2", templateData.Sidecars[0].EnvironmentVariables["MY_OTHER_CUSTOM_ENV"])
 	})
 
+	t.Run("SetsCloudSQLProxySpecificArgsToSidecarSpecificProperties", func(t *testing.T) {
+
+		params := Params{
+			Sidecar: SidecarParams{
+				HealthCheckPath:                   "testHealthCheckPath",
+				DbInstanceConnectionName:          "testDbInstanceConnectionName",
+				SQLProxyPort:                      15,
+				SQLProxyTerminationTimeoutSeconds: 16,
+			},
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "", "")
+
+		assert.Equal(t, 4, len(templateData.Sidecars[0].SidecarSpecificProperties))
+		assert.Equal(t, "testHealthCheckPath", templateData.Sidecars[0].SidecarSpecificProperties["healthcheckpath"])
+		assert.Equal(t, "testDbInstanceConnectionName", templateData.Sidecars[0].SidecarSpecificProperties["dbinstanceconnectionname"])
+		assert.Equal(t, 15, templateData.Sidecars[0].SidecarSpecificProperties["sqlproxyport"])
+		assert.Equal(t, 16, templateData.Sidecars[0].SidecarSpecificProperties["sqlproxyterminationtimeoutseconds"])
+	})
+
 	t.Run("SetsSecretsToSecretsParam", func(t *testing.T) {
 
 		params := Params{

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -219,7 +219,8 @@ spec:
             memory: {{.MemoryLimit}}
         command: ["/cloud_sql_proxy",
                   "-instances={{ index .SidecarSpecificProperties "dbinstanceconnectionname" }}=tcp:{{ index .SidecarSpecificProperties "sqlproxyport" }}",
-                  "-credential_file=/gcp-service-account/service-account-key.json"]
+                  "-credential_file=/gcp-service-account/service-account-key.json",
+                  "-term_timeout={{ index .SidecarSpecificProperties "sqlproxyterminationtimeoutseconds" }}s"]
           {{- if $deployment.MountServiceAccountSecret }}
         volumeMounts:
           - name: gcp-service-account


### PR DESCRIPTION
We have some sporadic connection issues with the Cloud SQL Proxy, looking similar to https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/184

It might be caused by the proxy sidecar being stopped earlier than the main container when a pod terminates. This has been improved in https://github.com/GoogleCloudPlatform/cloudsql-proxy/pull/206, where the new `term_timeout` argument was introduced to give the existing connections close before the sidecar is stopped.

In this PR a new field is introduced to make it possible to customize this.