### PR TITLE
Refactor template data to make https use more explicit.

### DIFF
--- a/params.go
+++ b/params.go
@@ -838,9 +838,20 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 		warnings = append(warnings, "The sidecar field is deprecated, the sidecars list should be used instead.")
 	}
 
+	// check if openresty was defined as deprecated sidecar type
+	hasOpenrestySidecar := p.Sidecar.Type == "openresty"
+
 	// validate sidecars params
 	for _, sidecar := range p.Sidecars {
 		errors = p.validateSidecar(sidecar, errors)
+		if sidecar.Type == "openresty" {
+			hasOpenrestySidecar = true
+		}
+	}
+
+	// openresty sidecar cannot be added in combination with port 443
+	if hasOpenrestySidecar && p.Container.Port == 443 {
+		errors = append(errors, fmt.Errorf("Container port can't be 443 if an openresty sidecar is injected."))
 	}
 
 	// validate load balance algorithm

--- a/templateData.go
+++ b/templateData.go
@@ -44,7 +44,7 @@ type TemplateData struct {
 	Sidecars                             []SidecarData
 	HasInitContainers                    bool
 	InitContainers                       []*map[string]interface{}
-	HasOpenrestySidecar                  bool
+	UseHTTPS                             bool
 	UseESP                               bool
 	HasEspConfigID                       bool
 	EspConfigID                          string

--- a/templateData.go
+++ b/templateData.go
@@ -44,7 +44,7 @@ type TemplateData struct {
 	Sidecars                             []SidecarData
 	HasInitContainers                    bool
 	InitContainers                       []*map[string]interface{}
-	UseHTTPS                             bool
+	HasOpenrestySidecar                  bool
 	UseESP                               bool
 	HasEspConfigID                       bool
 	EspConfigID                          string
@@ -85,6 +85,7 @@ type TemplateData struct {
 	NginxIngressProxyBuffersNumber       string
 	SetsNginxIngressLoadBalanceAlgorithm bool
 	NginxIngressLoadBalanceAlgorithm     string
+	UseHTTPS                             bool
 
 	IncludeReplicas                 bool
 	Replicas                        int

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -138,12 +138,12 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		data.Container.EnvironmentVariables = addEnvironmentVariableIfNotSet(data.Container.EnvironmentVariables, "JAEGER_SAMPLER_PARAM", "0.001")
 	}
 
-	hasOpenrestySidecar := false
+	data.HasOpenrestySidecar = false
 	for _, sidecarParams := range params.Sidecars {
 		sidecar := buildSidecar(sidecarParams, params)
 		data.Sidecars = append(data.Sidecars, sidecar)
 		if sidecar.Type == "openresty" {
-			hasOpenrestySidecar = true
+			data.HasOpenrestySidecar = true
 		}
 	}
 	data.UseESP = params.Visibility == "esp"
@@ -155,10 +155,10 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		data.InitContainers = params.InitContainers
 	}
 
-	data.Container.Readiness.IncludeOnContainer = !hasOpenrestySidecar || params.Container.ReadinessProbe.Port != params.Container.Port || params.Container.ReadinessProbe.Path != params.Sidecar.HealthCheckPath
+	data.Container.Readiness.IncludeOnContainer = !data.HasOpenrestySidecar || params.Container.ReadinessProbe.Port != params.Container.Port || params.Container.ReadinessProbe.Path != params.Sidecar.HealthCheckPath
 
 	// if container port is set to 443, we always use https named port
-	data.UseHTTPS = hasOpenrestySidecar || params.Container.Port == 443
+	data.UseHTTPS = data.HasOpenrestySidecar || params.Container.Port == 443
 
 	// set request params on the nginx ingress
 	requestTimeout, requestTimeoutConvertError := strconv.Atoi(strings.Trim(params.Request.Timeout, "s"))

--- a/templates/ingress-internal.yaml
+++ b/templates/ingress-internal.yaml
@@ -46,7 +46,7 @@ spec:
       - path: {{$.InternalIngressPath}}
         backend:
           serviceName: {{$.Name}}
-          {{- if $.UseHTTPS }}
+          {{- if $.HasOpenrestySidecar }}
           servicePort: https
           {{- else }}
           servicePort: web

--- a/templates/ingress-internal.yaml
+++ b/templates/ingress-internal.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- end}}
   annotations:
     kubernetes.io/ingress.class: "nginx-internal"
-    {{- if .HasOpenrestySidecar }}
+    {{- if .UseHTTPS }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     {{- end }}
     nginx.ingress.kubernetes.io/client-body-buffer-size: "{{.NginxIngressClientBodyBufferSize}}"
@@ -46,7 +46,7 @@ spec:
       - path: {{$.InternalIngressPath}}
         backend:
           serviceName: {{$.Name}}
-          {{- if $.HasOpenrestySidecar }}
+          {{- if $.UseHTTPS }}
           servicePort: https
           {{- else }}
           servicePort: web

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -55,7 +55,7 @@ spec:
       - path: {{$.IngressPath}}
         backend:
           serviceName: {{$.Name}}
-          {{- if $.UseHTTPS }}
+          {{- if $.HasOpenrestySidecar }}
           servicePort: https
           {{- else }}
           servicePort: web

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     {{- if .UseNginxIngress}}
     kubernetes.io/ingress.class: "nginx-office"
-    {{- if .HasOpenrestySidecar }}
+    {{- if .UseHTTPS }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     {{- end }}
     nginx.ingress.kubernetes.io/client-body-buffer-size: "{{.NginxIngressClientBodyBufferSize}}"
@@ -55,7 +55,7 @@ spec:
       - path: {{$.IngressPath}}
         backend:
           serviceName: {{$.Name}}
-          {{- if $.HasOpenrestySidecar }}
+          {{- if $.UseHTTPS }}
           servicePort: https
           {{- else }}
           servicePort: web

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -30,7 +30,7 @@ spec:
   {{- end}}
   {{- end}}
   ports:
-  {{- if .UseHTTPS }}
+  {{- if .HasOpenrestySidecar }}
   {{- if not .UseESP }}
   - name: http
     port: 80

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -30,7 +30,7 @@ spec:
   {{- end}}
   {{- end}}
   ports:
-  {{- if .HasOpenrestySidecar }}
+  {{- if .UseHTTPS }}
   {{- if not .UseESP }}
   - name: http
     port: 80


### PR DESCRIPTION
In some cases the user doesn't want to use the openresty sidecar but still wants to listen on the HTTPS port.