### PR TITLE
deprecated visibility public

### DIFF
--- a/params.go
+++ b/params.go
@@ -725,6 +725,9 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 		if p.Visibility == "" || (p.Visibility != "private" && p.Visibility != "public" && p.Visibility != "iap" && p.Visibility != "esp" && p.Visibility != "public-whitelist" && p.Visibility != "apigee") {
 			errors = append(errors, fmt.Errorf("Visibility property is required; set it via visibility property on this stage; allowed values are private, iap, esp, public-whitelist, public or apigee"))
 		}
+		if p.Visibility == "public" {
+			warnings = append(warnings, "Visibility public is deprecated, please use esp or apigee.")
+		}
 		if p.Visibility == "iap" && p.IapOauthCredentialsClientID == "" {
 			errors = append(errors, fmt.Errorf("With visibility 'iap' property iapOauthClientID is required; set it via iapOauthClientID property on this stage"))
 		}

--- a/params_test.go
+++ b/params_test.go
@@ -3763,6 +3763,18 @@ func TestValidateRequiredProperties(t *testing.T) {
 		assert.False(t, valid)
 		assert.Equal(t, 1, len(errors))
 	})
+
+	t.Run("WarnOnUsingVisibilityPublic", func(t *testing.T) {
+
+		params := validParams
+		params.Visibility = "public"
+
+		// act
+		valid, _, warnings := params.ValidateRequiredProperties()
+
+		assert.True(t, valid)
+		assert.Equal(t, 1, len(warnings))
+	})
 }
 
 func TestReplaceSidecarTagsWithDigest(t *testing.T) {


### PR DESCRIPTION
Visibility public is deprecated, so build will fail if it tries to create new service with public visibility. Added warning when using public visibility.