### PR TITLE
Container-native load balancing support

### DIFF
--- a/main.go
+++ b/main.go
@@ -303,6 +303,7 @@ func main() {
 				deleteIngressForVisibilityChange(ctx, templateData, templateData.Name, templateData.Namespace)
 				removeEstafetteCloudflareAnnotations(ctx, templateData, templateData.Name, templateData.Namespace)
 				removeBackendConfigAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
+				removeNegAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
 				deleteBackendConfigAndIAPOauthSecret(ctx, templateData, templateData.Name, templateData.Namespace)
 				deleteHorizontalPodAutoscaler(ctx, params, templateData.NameWithTrack, templateData.Namespace)
 				break
@@ -318,6 +319,7 @@ func main() {
 				deleteIngressForVisibilityChange(ctx, templateData, templateData.Name, templateData.Namespace)
 				removeEstafetteCloudflareAnnotations(ctx, templateData, templateData.Name, templateData.Namespace)
 				removeBackendConfigAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
+				removeNegAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
 				deleteBackendConfigAndIAPOauthSecret(ctx, templateData, templateData.Name, templateData.Namespace)
 				deleteHorizontalPodAutoscaler(ctx, params, templateData.Name, templateData.Namespace)
 				break
@@ -623,6 +625,14 @@ func removeBackendConfigAnnotation(ctx context.Context, templateData TemplateDat
 		// iap is not used, so the beta.cloud.google.com/backend-config annotations should be removed from the service
 		log.Info().Msg("Removing beta.cloud.google.com/backend-config annotations on the service if they exists, since visibility is not set to iap...")
 		foundation.RunCommandWithArgs(ctx, "kubectl", []string{"annotate", "svc", name, "-n", namespace, "beta.cloud.google.com/backend-config-"})
+	}
+}
+
+func removeNegAnnotation(ctx context.Context, templateData TemplateData, name, namespace string) {
+	if !templateData.UseNegAnnotationOnService {
+		// cloud native load balancing is not used, so the beta.cloud.google.com/backend-config annotations should be removed from the service
+		log.Info().Msg("Removing cloud.google.com/neg annotations on the service if they exists, since visibility is not set to iap or containerNativeLoadBalancing is set to fals...")
+		foundation.RunCommandWithArgs(ctx, "kubectl", []string{"annotate", "svc", name, "-n", namespace, "cloud.google.com/neg-"})
 	}
 }
 

--- a/params.go
+++ b/params.go
@@ -36,6 +36,7 @@ type Params struct {
 	StorageMountPath                string              `json:"storagemountpath,omitempty" yaml:"storagemountpath,omitempty"`
 	Labels                          map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Visibility                      string              `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+	ContainerNativeLoadBalancing    bool                `json:"containerNativeLoadBalancing,omitempty" yaml:"containerNativeLoadBalancing,omitempty"`
 	IapOauthCredentialsClientID     string              `json:"iapOauthClientID,omitempty" yaml:"iapOauthClientID,omitempty"`
 	IapOauthCredentialsClientSecret string              `json:"iapOauthClientSecret,omitempty" yaml:"iapOauthClientSecret,omitempty"`
 	EspConfigID                     string              `json:"espConfigID,omitempty" yaml:"espConfigID,omitempty"`

--- a/templateData.go
+++ b/templateData.go
@@ -31,6 +31,7 @@ type TemplateData struct {
 	UseCloudflareProxy                   bool
 	UseDNSAnnotationsOnService           bool
 	UseBackendConfigAnnotationOnService  bool
+	UseNegAnnotationOnService            bool
 	UsePrometheusProbe                   bool
 	ServiceType                          string
 	MinReplicas                          int

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -268,6 +268,7 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		data.UseDNSAnnotationsOnService = false
 		data.UseCloudflareProxy = true
 		data.UseBackendConfigAnnotationOnService = false
+		data.UseNegAnnotationOnService = false
 		data.LimitTrustedIPRanges = false
 		data.OverrideDefaultWhitelist = false
 
@@ -279,6 +280,7 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		data.UseDNSAnnotationsOnService = false
 		data.UseCloudflareProxy = false
 		data.UseBackendConfigAnnotationOnService = true
+		data.UseNegAnnotationOnService = params.ContainerNativeLoadBalancing
 		data.LimitTrustedIPRanges = false
 		data.OverrideDefaultWhitelist = false
 		data.IapOauthCredentialsClientID = params.IapOauthCredentialsClientID
@@ -292,6 +294,7 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		data.UseDNSAnnotationsOnService = false
 		data.UseCloudflareProxy = true
 		data.UseBackendConfigAnnotationOnService = false
+		data.UseNegAnnotationOnService = false
 		data.LimitTrustedIPRanges = false
 		data.OverrideDefaultWhitelist = len(params.WhitelistedIPS) > 0
 		data.NginxIngressWhitelist = strings.Join(params.WhitelistedIPS, ",")
@@ -304,6 +307,7 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		data.UseDNSAnnotationsOnService = false
 		data.UseCloudflareProxy = true // For private ingress. For Apigee it is hard-coded to be false.
 		data.UseBackendConfigAnnotationOnService = false
+		data.UseNegAnnotationOnService = false
 		data.LimitTrustedIPRanges = false
 		data.OverrideDefaultWhitelist = false
 		for _, h := range params.Hosts {

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -21,6 +21,9 @@ metadata:
     {{- if .UseBackendConfigAnnotationOnService}}
     beta.cloud.google.com/backend-config: '{"default": "{{.Name}}"}'
     {{- end}}
+    {{- if .UseNegAnnotationOnService}}
+    cloud.google.com/neg: '{"ingress": true}'
+    {{- end}}
 spec:
   type: {{.ServiceType}}
   {{- if .LimitTrustedIPRanges}}


### PR DESCRIPTION
Add containerNativeLoadBalancing param to enable container native load balancing in combination with visibility iap.

See https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing

This should result in more reliable load balancing without having requests being bounced around by kube-proxy, but going straight from google's http load balancer towards the pod. Only works for clusters with ip-alias enabled.