### PR TITLE
set estafette.io/pipeline label on all resources

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func main() {
 	}
 
 	log.Info().Msg("Setting defaults for parameters that are not set in the manifest...")
-	params.SetDefaults(*gitName, *appLabel, *buildVersion, *releaseName, *releaseAction, estafetteLabels)
+	params.SetDefaults(*gitSource, *gitOwner, *gitName, *appLabel, *buildVersion, *releaseName, *releaseAction, estafetteLabels)
 
 	log.Info().Msg("Validating required parameters...")
 	valid, errors, warnings := params.ValidateRequiredProperties()

--- a/params.go
+++ b/params.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -263,7 +264,12 @@ func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersio
 	}
 	if gitSource != "" && gitOwner != "" && gitName != "" {
 		// add estafette.io/pipeline label to labels set on all resources for linking catalog entities back to pipelines
-		p.Labels["estafette.io/pipeline"] = sanitizeLabel(fmt.Sprintf("%v/%v/%v", gitSource, gitOwner, gitName))
+
+		pipeline := fmt.Sprintf("%v/%v/%v", gitSource, gitOwner, gitName)
+		pipelineBase64 := base64.StdEncoding.EncodeToString([]byte(pipeline))
+
+		p.Labels["estafette.io/pipeline"] = sanitizeLabel(pipeline)
+		p.Labels["estafette.io/pipeline-base64"] = sanitizeLabel(pipelineBase64)
 	}
 
 	// default visibility to private if no override in stage params

--- a/params.go
+++ b/params.go
@@ -212,7 +212,7 @@ type VolumeMountParams struct {
 }
 
 // SetDefaults fills in empty fields with convention-based defaults
-func (p *Params) SetDefaults(gitName, appLabel, buildVersion, releaseName, releaseAction string, estafetteLabels map[string]string) {
+func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersion, releaseName, releaseAction string, estafetteLabels map[string]string) {
 
 	p.BuildVersion = buildVersion
 
@@ -260,6 +260,10 @@ func (p *Params) SetDefaults(gitName, appLabel, buildVersion, releaseName, relea
 	// ensure the app label is set and equals the app label or app override in stage params if present
 	if p.App != "" {
 		p.Labels["app"] = p.App
+	}
+	if gitSource != "" && gitOwner != "" && gitName != "" {
+		// add estafette.io/pipeline label to labels set on all resources for linking catalog entities back to pipelines
+		p.Labels["estafette.io/pipeline"] = sanitizeLabel(fmt.Sprintf("%v/%v/%v", gitSource, gitOwner, gitName))
 	}
 
 	// default visibility to private if no override in stage params

--- a/params_test.go
+++ b/params_test.go
@@ -126,7 +126,7 @@ func TestSetDefaults(t *testing.T) {
 		appLabel := ""
 
 		// act
-		params.SetDefaults(gitName, appLabel, "", "", "", map[string]string{})
+		params.SetDefaults("", "", gitName, appLabel, "", "", "", map[string]string{})
 
 		assert.Equal(t, "mygitrepo", params.App)
 	})
@@ -139,7 +139,7 @@ func TestSetDefaults(t *testing.T) {
 		appLabel := "myapp"
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", appLabel, "", "", "", map[string]string{})
 
 		assert.Equal(t, "myapp", params.App)
 	})
@@ -152,7 +152,7 @@ func TestSetDefaults(t *testing.T) {
 		appLabel := "myapp"
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", appLabel, "", "", "", map[string]string{})
 
 		assert.Equal(t, "yourapp", params.App)
 	})
@@ -166,7 +166,7 @@ func TestSetDefaults(t *testing.T) {
 		appLabel := "myapp"
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", appLabel, "", "", "", map[string]string{})
 
 		assert.Equal(t, "yourapp", params.GoogleCloudCredentialsApp)
 	})
@@ -180,7 +180,7 @@ func TestSetDefaults(t *testing.T) {
 		appLabel := "someapp"
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", appLabel, "", "", "", map[string]string{})
 
 		assert.Equal(t, "myapp", params.GoogleCloudCredentialsApp)
 	})
@@ -195,7 +195,7 @@ func TestSetDefaults(t *testing.T) {
 		appLabel := "myapp"
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", appLabel, "", "", "", map[string]string{})
 
 		assert.Equal(t, "myapp", params.Container.ImageName)
 	})
@@ -210,7 +210,7 @@ func TestSetDefaults(t *testing.T) {
 		appLabel := "myapp"
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", appLabel, "", "", "", map[string]string{})
 
 		assert.Equal(t, "my-app", params.Container.ImageName)
 	})
@@ -225,7 +225,7 @@ func TestSetDefaults(t *testing.T) {
 		buildVersion := "1.0.0"
 
 		// act
-		params.SetDefaults("", "", buildVersion, "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", buildVersion, "", "", map[string]string{})
 
 		assert.Equal(t, "1.0.0", params.Container.ImageTag)
 	})
@@ -240,7 +240,7 @@ func TestSetDefaults(t *testing.T) {
 		buildVersion := "1.0.0"
 
 		// act
-		params.SetDefaults("", "", buildVersion, "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", buildVersion, "", "", map[string]string{})
 
 		assert.Equal(t, "2.1.3", params.Container.ImageTag)
 	})
@@ -257,7 +257,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", estafetteLabels)
+		params.SetDefaults("", "", "", "", "", "", "", estafetteLabels)
 
 		assert.Equal(t, 3, len(params.Labels))
 		assert.Equal(t, "myapp", params.Labels["app"])
@@ -280,7 +280,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", estafetteLabels)
+		params.SetDefaults("", "", "", "", "", "", "", estafetteLabels)
 
 		assert.Equal(t, 2, len(params.Labels))
 		assert.Equal(t, "yourapp", params.Labels["app"])
@@ -302,7 +302,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", estafetteLabels)
+		params.SetDefaults("", "", "", appLabel, "", "", "", estafetteLabels)
 
 		assert.Equal(t, 2, len(params.Labels))
 		assert.Equal(t, "myapp", params.Labels["app"])
@@ -320,7 +320,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", appLabel, "", "", "", estafetteLabels)
+		params.SetDefaults("", "", "", appLabel, "", "", "", estafetteLabels)
 
 		assert.Equal(t, 3, len(params.Labels))
 		assert.Equal(t, "yourapp", params.Labels["app"])
@@ -335,7 +335,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "private", params.Visibility)
 	})
@@ -347,7 +347,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "public", params.Visibility)
 	})
@@ -364,7 +364,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "100m", params.Container.CPU.Request)
 	})
@@ -381,7 +381,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "300m", params.Container.CPU.Request)
 	})
@@ -398,7 +398,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "250m", params.Container.CPU.Request)
 	})
@@ -415,7 +415,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "125m", params.Container.CPU.Limit)
 	})
@@ -432,7 +432,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "300m", params.Container.CPU.Limit)
 	})
@@ -449,7 +449,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "250m", params.Container.CPU.Limit)
 	})
@@ -466,7 +466,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "128Mi", params.Container.Memory.Request)
 	})
@@ -483,7 +483,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "256Mi", params.Container.Memory.Request)
 	})
@@ -500,7 +500,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "512Mi", params.Container.Memory.Request)
 	})
@@ -517,7 +517,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "128Mi", params.Container.Memory.Limit)
 	})
@@ -534,7 +534,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "768Mi", params.Container.Memory.Limit)
 	})
@@ -551,7 +551,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "1024Mi", params.Container.Memory.Limit)
 	})
@@ -565,7 +565,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5000, params.Container.Port)
 	})
@@ -579,7 +579,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3000, params.Container.Port)
 	})
@@ -597,7 +597,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "TCP", params.Container.AdditionalPorts[0].Protocol)
 	})
@@ -615,7 +615,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "UDP", params.Container.AdditionalPorts[0].Protocol)
 	})
@@ -634,7 +634,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "public", params.Container.AdditionalPorts[0].Visibility)
 	})
@@ -653,7 +653,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "private", params.Container.AdditionalPorts[0].Visibility)
 	})
@@ -667,7 +667,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, params.Autoscale.MinReplicas)
 	})
@@ -681,7 +681,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 2, params.Autoscale.MinReplicas)
 	})
@@ -695,7 +695,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 100, params.Autoscale.MaxReplicas)
 	})
@@ -709,7 +709,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 50, params.Autoscale.MaxReplicas)
 	})
@@ -723,7 +723,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 80, params.Autoscale.CPUPercentage)
 	})
@@ -737,7 +737,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 30, params.Autoscale.CPUPercentage)
 	})
@@ -751,7 +751,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.False(t, params.Autoscale.Safety.Enabled)
 	})
@@ -767,7 +767,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.True(t, params.Autoscale.Safety.Enabled)
 	})
@@ -782,7 +782,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "sum(rate(nginx_http_requests_total{app='my-app'}[5m])) by (app)", params.Autoscale.Safety.PromQuery)
 	})
@@ -799,7 +799,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "sum(rate(nginx_http_requests_total{app='your-app'}[5m])) by (app)", params.Autoscale.Safety.PromQuery)
 	})
@@ -814,7 +814,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "1", params.Autoscale.Safety.Ratio)
 	})
@@ -831,7 +831,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "1.5", params.Autoscale.Safety.Ratio)
 	})
@@ -846,7 +846,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "1", params.Autoscale.Safety.ScaleDownRatio)
 	})
@@ -863,7 +863,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "0.2", params.Autoscale.Safety.ScaleDownRatio)
 	})
@@ -877,7 +877,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "60s", params.Request.Timeout)
 	})
@@ -891,7 +891,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "10s", params.Request.Timeout)
 	})
@@ -905,7 +905,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "128m", params.Request.MaxBodySize)
 	})
@@ -919,7 +919,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "16m", params.Request.MaxBodySize)
 	})
@@ -933,7 +933,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "4k", params.Request.ProxyBufferSize)
 	})
@@ -947,7 +947,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "8k", params.Request.ProxyBufferSize)
 	})
@@ -963,7 +963,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 30, params.Container.LivenessProbe.InitialDelaySeconds)
 	})
@@ -979,7 +979,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 120, params.Container.LivenessProbe.InitialDelaySeconds)
 	})
@@ -995,7 +995,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 1, params.Container.LivenessProbe.TimeoutSeconds)
 	})
@@ -1011,7 +1011,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5, params.Container.LivenessProbe.TimeoutSeconds)
 	})
@@ -1027,7 +1027,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, params.Container.LivenessProbe.FailureThreshold)
 	})
@@ -1043,7 +1043,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5, params.Container.LivenessProbe.FailureThreshold)
 	})
@@ -1059,7 +1059,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 1, params.Container.LivenessProbe.SuccessThreshold)
 	})
@@ -1075,7 +1075,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5, params.Container.LivenessProbe.SuccessThreshold)
 	})
@@ -1091,7 +1091,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/liveness", params.Container.LivenessProbe.Path)
 	})
@@ -1107,7 +1107,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/healthz", params.Container.LivenessProbe.Path)
 	})
@@ -1124,7 +1124,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 8080, params.Container.LivenessProbe.Port)
 	})
@@ -1141,7 +1141,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 8081, params.Container.LivenessProbe.Port)
 	})
@@ -1157,7 +1157,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 0, params.Container.ReadinessProbe.InitialDelaySeconds)
 	})
@@ -1173,7 +1173,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 120, params.Container.ReadinessProbe.InitialDelaySeconds)
 	})
@@ -1189,7 +1189,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 1, params.Container.ReadinessProbe.TimeoutSeconds)
 	})
@@ -1205,7 +1205,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5, params.Container.ReadinessProbe.TimeoutSeconds)
 	})
@@ -1221,7 +1221,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, params.Container.ReadinessProbe.FailureThreshold)
 	})
@@ -1237,7 +1237,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5, params.Container.ReadinessProbe.FailureThreshold)
 	})
@@ -1253,7 +1253,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 1, params.Container.ReadinessProbe.SuccessThreshold)
 	})
@@ -1269,7 +1269,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5, params.Container.ReadinessProbe.SuccessThreshold)
 	})
@@ -1285,7 +1285,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/readiness", params.Container.ReadinessProbe.Path)
 	})
@@ -1301,7 +1301,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/healthz", params.Container.ReadinessProbe.Path)
 	})
@@ -1318,7 +1318,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 8080, params.Container.ReadinessProbe.Port)
 	})
@@ -1335,7 +1335,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 8082, params.Container.ReadinessProbe.Port)
 	})
@@ -1347,7 +1347,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, true, *params.ProbeService)
 	})
@@ -1359,7 +1359,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, false, *params.ProbeService)
 	})
@@ -1375,7 +1375,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/metrics", params.Container.Metrics.Path)
 	})
@@ -1391,7 +1391,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/mymetrics", params.Container.Metrics.Path)
 	})
@@ -1408,7 +1408,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5000, params.Container.Metrics.Port)
 	})
@@ -1425,7 +1425,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 5001, params.Container.Metrics.Port)
 	})
@@ -1441,7 +1441,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, true, *params.Container.Metrics.Scrape)
 	})
@@ -1457,7 +1457,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, false, *params.Container.Metrics.Scrape)
 	})
@@ -1473,7 +1473,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, true, *params.Container.Lifecycle.PrestopSleep)
 	})
@@ -1489,7 +1489,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, false, *params.Container.Lifecycle.PrestopSleep)
 	})
@@ -1505,7 +1505,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 20, *params.Container.Lifecycle.PrestopSleepSeconds)
 	})
@@ -1523,7 +1523,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 25, *params.Container.Lifecycle.PrestopSleepSeconds)
 	})
@@ -1538,7 +1538,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "openresty", params.Sidecars[0].Type)
 	})
@@ -1553,7 +1553,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 0, len(params.Sidecars))
 	})
@@ -1570,7 +1570,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 0, len(params.Sidecars))
 	})
@@ -1585,7 +1585,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 0, len(params.Sidecars))
 		assert.Equal(t, "", params.Sidecar.Type)
@@ -1600,7 +1600,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "istio", params.Sidecar.Type)
 	})
@@ -1614,7 +1614,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		// digest for estafette/openresty-sidecar:1.5.8.2
 		assert.Equal(t, "estafette/openresty-sidecar@sha256:09630e7c5141d44b14a8bb7581c6316876353535e762e35e54f3339de1f5211b", params.Sidecars[0].Image)
@@ -1637,7 +1637,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 4, len(params.Sidecars))
 		assert.Equal(t, "prometheus", params.Sidecars[0].Type)
@@ -1663,7 +1663,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, len(params.Sidecars))
 		assert.Equal(t, "openresty", params.Sidecars[0].Type)
@@ -1688,7 +1688,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, len(params.Sidecars))
 		assert.Equal(t, "istio", params.Sidecars[0].Type)
@@ -1705,7 +1705,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "estafette/openresty-sidecar:latest", params.Sidecar.Image)
 	})
@@ -1725,7 +1725,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/myreadiness", params.Sidecar.HealthCheckPath)
 	})
@@ -1743,7 +1743,7 @@ func TestSetDefaults(t *testing.T) {
 			},
 		}
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/nomyreadiness", params.Sidecar.HealthCheckPath)
 	})
@@ -1760,7 +1760,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "50m", params.Sidecar.CPU.Request)
 	// })
@@ -1777,7 +1777,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "300m", params.Sidecar.CPU.Request)
 	// })
@@ -1794,7 +1794,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "250m", params.Sidecar.CPU.Request)
 	// })
@@ -1811,7 +1811,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "75m", params.Sidecar.CPU.Limit)
 	// })
@@ -1828,7 +1828,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "300m", params.Sidecar.CPU.Limit)
 	// })
@@ -1845,7 +1845,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "250m", params.Sidecar.CPU.Limit)
 	// })
@@ -1862,7 +1862,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "30Mi", params.Sidecar.Memory.Request)
 	// })
@@ -1879,7 +1879,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "256Mi", params.Sidecar.Memory.Request)
 	// })
@@ -1896,7 +1896,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "512Mi", params.Sidecar.Memory.Request)
 	// })
@@ -1913,7 +1913,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "50Mi", params.Sidecar.Memory.Limit)
 	// })
@@ -1930,7 +1930,7 @@ func TestSetDefaults(t *testing.T) {
 	// 	}
 
 	// 	// act
-	// 	params.SetDefaults("", "", "", "", "", map[string]string{})
+	// 	params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 	// 	assert.Equal(t, "768Mi", params.Sidecar.Memory.Limit)
 	// })
@@ -1947,7 +1947,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "1024Mi", params.Sidecar.Memory.Limit)
 	})
@@ -1966,7 +1966,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "testReadinessPath", params.Sidecar.HealthCheckPath)
 	})
@@ -1986,7 +1986,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "testReadinessPath", params.Sidecar.HealthCheckPath)
 	})
@@ -1998,7 +1998,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/", params.Basepath)
 	})
@@ -2010,7 +2010,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/api", params.Basepath)
 	})
@@ -2024,7 +2024,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "25%", params.RollingUpdate.MaxSurge)
 	})
@@ -2038,7 +2038,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "10%", params.RollingUpdate.MaxSurge)
 	})
@@ -2052,7 +2052,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "0", params.RollingUpdate.MaxUnavailable)
 	})
@@ -2066,7 +2066,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "20%", params.RollingUpdate.MaxUnavailable)
 	})
@@ -2080,7 +2080,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "5m", params.RollingUpdate.Timeout)
 	})
@@ -2094,7 +2094,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "10m", params.RollingUpdate.Timeout)
 	})
@@ -2105,7 +2105,7 @@ func TestSetDefaults(t *testing.T) {
 		buildVersion := "1.0.0"
 
 		// act
-		params.SetDefaults("", "", buildVersion, "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", buildVersion, "", "", map[string]string{})
 
 		assert.Equal(t, "1.0.0", params.BuildVersion)
 	})
@@ -2119,7 +2119,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/configs", params.Configs.MountPath)
 	})
@@ -2133,7 +2133,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/etc/app-config", params.Configs.MountPath)
 	})
@@ -2147,7 +2147,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/secrets", params.Secrets.MountPath)
 	})
@@ -2161,7 +2161,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "/etc/app-secret", params.Secrets.MountPath)
 	})
@@ -2173,7 +2173,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 14, len(params.TrustedIPRanges))
 		assert.Equal(t, "103.21.244.0/22", params.TrustedIPRanges[0])
@@ -2189,7 +2189,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 1, len(params.TrustedIPRanges))
 		assert.Equal(t, "0.0.0.0/0", params.TrustedIPRanges[0])
@@ -2202,7 +2202,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "deploy-simple", params.Action)
 	})
@@ -2214,7 +2214,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "deploy-canary", params.Action)
 	})
@@ -2226,7 +2226,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "rollback-canary", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "rollback-canary", map[string]string{})
 
 		assert.Equal(t, "rollback-canary", params.Action)
 	})
@@ -2238,7 +2238,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "rollback-canary", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "rollback-canary", map[string]string{})
 
 		assert.Equal(t, "rollback-canary", params.Action)
 	})
@@ -2250,7 +2250,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "deployment", params.Kind)
 	})
@@ -2263,7 +2263,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "Allow", params.ConcurrencyPolicy)
 	})
@@ -2275,7 +2275,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "OnFailure", params.RestartPolicy)
 	})
@@ -2287,7 +2287,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "Never", params.RestartPolicy)
 	})
@@ -2299,7 +2299,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 1, params.Completions)
 	})
@@ -2311,7 +2311,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, params.Completions)
 	})
@@ -2323,7 +2323,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 1, params.Parallelism)
 	})
@@ -2335,7 +2335,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, params.Parallelism)
 	})
@@ -2347,7 +2347,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 6, params.BackoffLimit)
 	})
@@ -2359,7 +2359,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, params.BackoffLimit)
 	})
@@ -2371,7 +2371,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "job", params.Kind)
 	})
@@ -2384,7 +2384,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "Parallel", params.PodManagementPolicy)
 	})
@@ -2397,7 +2397,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "standard", params.StorageClass)
 	})
@@ -2410,7 +2410,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, "1Gi", params.StorageSize)
 	})
@@ -2423,7 +2423,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
 		assert.Equal(t, 3, params.Request.VerifyDepth)
 	})

--- a/params_test.go
+++ b/params_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -307,6 +308,44 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, 2, len(params.Labels))
 		assert.Equal(t, "myapp", params.Labels["app"])
 		assert.Equal(t, "yourteam", params.Labels["team"])
+	})
+
+	t.Run("AddsEstafettePipelineLabel", func(t *testing.T) {
+
+		params := Params{
+			Labels: map[string]string{},
+		}
+		estafetteLabels := map[string]string{
+			"app":      "myapp",
+			"team":     "myteam",
+			"language": "golang",
+		}
+
+		// act
+		params.SetDefaults("github.com", "estafette", "estafette-extensions-gke", "", "", "", "", estafetteLabels)
+
+		assert.Equal(t, "github.com-estafette-estafette-extensions-gke", params.Labels["estafette.io/pipeline"])
+	})
+
+	t.Run("AddsEstafettePipelineBase64Label", func(t *testing.T) {
+
+		params := Params{
+			Labels: map[string]string{},
+		}
+		estafetteLabels := map[string]string{
+			"app":      "myapp",
+			"team":     "myteam",
+			"language": "golang",
+		}
+
+		// act
+		params.SetDefaults("github.com", "estafette", "estafette-extensions-gke", "", "", "", "", estafetteLabels)
+
+		assert.Equal(t, "Z2l0aHViLmNvbS9lc3RhZmV0dGUvZXN0YWZldHRlLWV4dGVuc2lvbnMtZ2tl", params.Labels["estafette.io/pipeline-base64"])
+
+		decodedLabel, err := base64.StdEncoding.DecodeString(params.Labels["estafette.io/pipeline-base64"])
+		assert.Nil(t, err)
+		assert.Equal(t, "github.com/estafette/estafette-extensions-gke", string(decodedLabel))
 	})
 
 	t.Run("OverwritesAppLabelToAppIfSetFromEstafetteLabels", func(t *testing.T) {

--- a/templateDataGenerator_test.go
+++ b/templateDataGenerator_test.go
@@ -2258,7 +2258,7 @@ func TestGenerateTemplateData(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("estafette-extension-gke", "sample-app", "0.1.0", "test", "deploy", nil)
+		params.SetDefaults("github.com", "estafette", "estafette-extension-gke", "sample-app", "0.1.0", "test", "deploy", nil)
 		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
 
 		assert.Equal(t, []string{"google-apigee.com", "travix-apigee.com", "test-app-apigee"}, templateData.ApigeeHosts)


### PR DESCRIPTION
In order to be able to link catalog entities - a feature I'm currently working on - back to pipelines I'm adding these label.

Entities I'm planning to extract from the cloud and store in the catalog entities table are projects, clusters, deployments, daemonsets, etc, etc.