### PR TITLE
allow backoffLimit param to be set to zero, still default to 6

### DIFF
--- a/params.go
+++ b/params.go
@@ -28,7 +28,7 @@ type Params struct {
 	RestartPolicy                   string              `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
 	Completions                     int                 `json:"completions,omitempty" yaml:"completions,omitempty"`
 	Parallelism                     int                 `json:"parallelism,omitempty" yaml:"parallelism,omitempty"`
-	BackoffLimit                    int                 `json:"backoffLimit,omitempty" yaml:"backoffLimit,omitempty"`
+	BackoffLimit                    *int                `json:"backoffLimit,omitempty" yaml:"backoffLimit,omitempty"`
 	ConcurrencyPolicy               string              `json:"concurrencypolicy,omitempty" yaml:"concurrencypolicy,omitempty"`
 	PodManagementPolicy             string              `json:"podManagementpolicy,omitempty" yaml:"podManagementpolicy,omitempty"`
 	Replicas                        int                 `json:"replicas,omitempty" yaml:"replicas,omitempty"`
@@ -567,8 +567,9 @@ func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersio
 	if p.Parallelism <= 0 {
 		p.Parallelism = 1
 	}
-	if p.BackoffLimit <= 0 {
-		p.BackoffLimit = 6
+	if p.BackoffLimit == nil || *p.BackoffLimit < 0 {
+		defaultBackoffLimit := 6
+		p.BackoffLimit = &defaultBackoffLimit
 	}
 
 	if p.Kind == "statefulset" {

--- a/params_test.go
+++ b/params_test.go
@@ -2382,25 +2382,39 @@ func TestSetDefaults(t *testing.T) {
 	t.Run("DefaultsBackoffLimitTo6", func(t *testing.T) {
 
 		params := Params{
-			BackoffLimit: 0,
+			BackoffLimit: nil,
 		}
 
 		// act
 		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
-		assert.Equal(t, 6, params.BackoffLimit)
+		assert.Equal(t, 6, *params.BackoffLimit)
 	})
 
 	t.Run("KeepsBackoffLimitIfSet", func(t *testing.T) {
 
+		backoffLimit := 3
 		params := Params{
-			BackoffLimit: 3,
+			BackoffLimit: &backoffLimit,
 		}
 
 		// act
 		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
-		assert.Equal(t, 3, params.BackoffLimit)
+		assert.Equal(t, 3, *params.BackoffLimit)
+	})
+
+	t.Run("KeepsBackoffLimitZeroIfSet", func(t *testing.T) {
+
+		backoffLimit := 0
+		params := Params{
+			BackoffLimit: &backoffLimit,
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
+
+		assert.Equal(t, 0, *params.BackoffLimit)
 	})
 
 	t.Run("KeepsKindIfNotEmpty", func(t *testing.T) {

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -20,7 +20,6 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		RestartPolicy:     params.RestartPolicy,
 		Completions:       params.Completions,
 		Parallelism:       params.Parallelism,
-		BackoffLimit:      params.BackoffLimit,
 		Labels:            sanitizeLabels(params.Labels),
 		PodLabels:         sanitizeLabels(params.Labels),
 		AppLabelSelector:  sanitizeLabel(params.App),
@@ -113,6 +112,10 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		// IsSimpleEnvvarValue returns true if a value should be wrapped in 'value: ""', otherwise the interface should be outputted as yaml
 		IsSimpleEnvvarValue: isSimpleEnvvarValue,
 		ToYAML:              toYAML,
+	}
+
+	if params.BackoffLimit != nil {
+		data.BackoffLimit = *params.BackoffLimit
 	}
 
 	if data.MountServiceAccountSecret {


### PR DESCRIPTION
In order to avoid a failing container in a cronjob to start again we need to set the following in the cronjob:

- `restartPolicy: OnFailure`
- `backoffLimit: 6`
- `concurrencyPolicy: Forbid`
 
See https://stackoverflow.com/a/51687712

However currently `backoffLimit: 0` will default it to `6`.