### PR TITLE
add support for action restart-simple, restart-canary and restart-stable

### DIFF
--- a/action.go
+++ b/action.go
@@ -1,0 +1,19 @@
+package main
+
+type ActionType string
+
+const (
+	ActionDeploySimple  ActionType = "deploy-simple"
+	ActionDeployCanary  ActionType = "deploy-canary"
+	ActionDeployStable  ActionType = "deploy-stable"
+	ActionRestartSimple ActionType = "restart-simple"
+	ActionRestartCanary ActionType = "restart-canary"
+	ActionRestartStable ActionType = "restart-stable"
+	ActionDiffSimple    ActionType = "diff-simple"
+	ActionDiffCanary    ActionType = "diff-canary"
+	ActionDiffStable    ActionType = "diff-stable"
+
+	ActionRollbackCanary ActionType = "rollback-canary"
+
+	ActionUnknown ActionType = ""
+)

--- a/main.go
+++ b/main.go
@@ -354,6 +354,15 @@ func main() {
 			case ActionRollbackCanary:
 				scaleCanaryDeployment(ctx, templateData.Name, templateData.Namespace, 0)
 				break
+			case ActionRestartCanary:
+				restartDeployment(ctx, fmt.Sprintf("%v-canary", templateData.Name), templateData.Namespace)
+				break
+			case ActionRestartStable:
+				restartDeployment(ctx, fmt.Sprintf("%v-stable", templateData.Name), templateData.Namespace)
+				break
+			case ActionRestartSimple:
+				restartDeployment(ctx, templateData.Name, templateData.Namespace)
+				break
 			case ActionDeploySimple:
 				deleteResourcesForTypeSwitch(ctx, fmt.Sprintf("%v-canary", templateData.Name), templateData.Namespace)
 				deleteResourcesForTypeSwitch(ctx, fmt.Sprintf("%v-stable", templateData.Name), templateData.Namespace)

--- a/main.go
+++ b/main.go
@@ -417,6 +417,7 @@ func scaleCanaryDeployment(ctx context.Context, name, namespace string, replicas
 func restartDeployment(ctx context.Context, name, namespace string) {
 	log.Info().Msgf("Restarting deployment rollout...")
 	foundation.RunCommandWithArgs(ctx, "kubectl", []string{"rollout", "restart", "deployment", name, "-n", namespace})
+	foundation.RunCommandWithArgsExtended(ctx, "kubectl", []string{"rollout", "status", "deployment", name, "-n", namespace})
 }
 
 func deleteResourcesForTypeSwitch(ctx context.Context, name, namespace string) {

--- a/params.go
+++ b/params.go
@@ -13,7 +13,7 @@ import (
 // Params is used to parameterize the deployment, set from custom properties in the manifest
 type Params struct {
 	// control params
-	Action          string          `json:"action,omitempty" yaml:"action,omitempty"`
+	Action          ActionType      `json:"action,omitempty" yaml:"action,omitempty"`
 	Kind            string          `json:"kind,omitempty" yaml:"kind,omitempty"`
 	DryRun          bool            `json:"dryrun,omitempty" yaml:"dryrun,omitempty"`
 	BuildVersion    string          `json:"-" yaml:"-"`
@@ -213,15 +213,15 @@ type VolumeMountParams struct {
 }
 
 // SetDefaults fills in empty fields with convention-based defaults
-func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersion, releaseName, releaseAction string, estafetteLabels map[string]string) {
+func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersion, releaseName string, releaseAction ActionType, estafetteLabels map[string]string) {
 
 	p.BuildVersion = buildVersion
 
 	// default action to deploy-simple unless it's either specified on the stage or passed in as a release action
-	if releaseAction != "" {
-		p.Action = releaseAction
-	} else if p.Action == "" && releaseAction == "" {
-		p.Action = "deploy-simple"
+	if releaseAction != ActionUnknown {
+		p.Action = ActionType(releaseAction)
+	} else if p.Action == "" && releaseAction == ActionUnknown {
+		p.Action = ActionDeploySimple
 	}
 
 	// default kind to deployment
@@ -656,7 +656,7 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 		errors = append(errors, fmt.Errorf("Namespace is required; either use credentials with a defaultNamespace or set it via namespace property on this stage"))
 	}
 
-	if p.Action == "rollback-canary" || p.Kind == "config" {
+	if p.Action == ActionRollbackCanary || p.Kind == "config" {
 		// the above properties are all you need for a rollback
 		return len(errors) == 0, errors, warnings
 	}

--- a/params_test.go
+++ b/params_test.go
@@ -12,7 +12,7 @@ var (
 	trueValue   = true
 	falseValue  = false
 	validParams = Params{
-		Action:    "deploy-simple",
+		Action:    ActionDeploySimple,
 		App:       "myapp",
 		Namespace: "mynamespace",
 		Autoscale: AutoscaleParams{
@@ -2243,31 +2243,31 @@ func TestSetDefaults(t *testing.T) {
 		// act
 		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
-		assert.Equal(t, "deploy-simple", params.Action)
+		assert.Equal(t, ActionDeploySimple, params.Action)
 	})
 
 	t.Run("KeepsActionIfNotEmpty", func(t *testing.T) {
 
 		params := Params{
-			Action: "deploy-canary",
+			Action: ActionDeployCanary,
 		}
 
 		// act
 		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
 
-		assert.Equal(t, "deploy-canary", params.Action)
+		assert.Equal(t, ActionDeployCanary, params.Action)
 	})
 
 	t.Run("OverridesActionIfActionIsNotEmptyButReleaseActionIsSet", func(t *testing.T) {
 
 		params := Params{
-			Action: "deploy-canary",
+			Action: ActionDeployCanary,
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", "", "rollback-canary", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", ActionRollbackCanary, map[string]string{})
 
-		assert.Equal(t, "rollback-canary", params.Action)
+		assert.Equal(t, ActionRollbackCanary, params.Action)
 	})
 
 	t.Run("SetsActionToReleaseActionIfActionIsEmptyAndReleaseActionIsSet", func(t *testing.T) {
@@ -2277,9 +2277,9 @@ func TestSetDefaults(t *testing.T) {
 		}
 
 		// act
-		params.SetDefaults("", "", "", "", "", "", "rollback-canary", map[string]string{})
+		params.SetDefaults("", "", "", "", "", "", ActionRollbackCanary, map[string]string{})
 
-		assert.Equal(t, "rollback-canary", params.Action)
+		assert.Equal(t, ActionRollbackCanary, params.Action)
 	})
 
 	t.Run("DefaultsKindToDeploymentIfEmpty", func(t *testing.T) {

--- a/templateBuilder.go
+++ b/templateBuilder.go
@@ -40,7 +40,7 @@ func buildTemplates(params Params, includePodDisruptionBudget bool) (*template.T
 
 func getTemplates(params Params, includePodDisruptionBudget bool) []string {
 
-	if params.Action == ActionRollbackCanary || params.Action == ActionUnknown {
+	if params.Action == ActionRollbackCanary || params.Action == ActionUnknown || params.Action == ActionRestartCanary || params.Action == ActionRestartStable || params.Action == ActionRestartSimple {
 		return []string{}
 	}
 

--- a/templateBuilder.go
+++ b/templateBuilder.go
@@ -40,7 +40,7 @@ func buildTemplates(params Params, includePodDisruptionBudget bool) (*template.T
 
 func getTemplates(params Params, includePodDisruptionBudget bool) []string {
 
-	if params.Action == "rollback-canary" {
+	if params.Action == ActionRollbackCanary || params.Action == ActionUnknown {
 		return []string{}
 	}
 
@@ -96,10 +96,10 @@ func getTemplates(params Params, includePodDisruptionBudget bool) []string {
 		}...)
 	}
 
-	if includePodDisruptionBudget && (params.Kind == "deployment" || params.Kind == "headless-deployment" || params.Kind == "statefulset") && (params.Action == "deploy-simple" || params.Action == "deploy-stable" || params.Action == "diff-simple" || params.Action == "diff-canary" || params.Action == "diff-stable") {
+	if includePodDisruptionBudget && (params.Kind == "deployment" || params.Kind == "headless-deployment" || params.Kind == "statefulset") && (params.Action == ActionDeploySimple || params.Action == ActionDeployStable || params.Action == ActionDiffSimple || params.Action == ActionDiffCanary || params.Action == ActionDiffStable) {
 		templatesToMerge = append(templatesToMerge, "poddisruptionbudget.yaml")
 	}
-	if (params.Kind == "deployment" || params.Kind == "headless-deployment") && params.Autoscale.Enabled != nil && *params.Autoscale.Enabled && params.StrategyType != "Recreate" && (params.Action == "deploy-simple" || params.Action == "deploy-stable" || params.Action == "diff-simple" || params.Action == "diff-canary" || params.Action == "diff-stable") {
+	if (params.Kind == "deployment" || params.Kind == "headless-deployment") && params.Autoscale.Enabled != nil && *params.Autoscale.Enabled && params.StrategyType != "Recreate" && (params.Action == ActionDeploySimple || params.Action == ActionDeployStable || params.Action == ActionDiffSimple || params.Action == ActionDiffCanary || params.Action == ActionDiffStable) {
 		templatesToMerge = append(templatesToMerge, "horizontalpodautoscaler.yaml")
 	}
 	if (params.Kind == "deployment" || params.Kind == "statefulset") && (params.Visibility == "private" || params.Visibility == "iap" || params.Visibility == "public-whitelist") {
@@ -157,7 +157,7 @@ func renderConfig(params Params) (renderedConfigFiles map[string]string) {
 
 	renderedConfigFiles = map[string]string{}
 
-	if params.Action != "rollback-canary" && (len(params.Configs.Files) > 0 || len(params.Configs.InlineFiles) > 0) {
+	if params.Action != ActionRollbackCanary && (len(params.Configs.Files) > 0 || len(params.Configs.InlineFiles) > 0) {
 		log.Info().Msg("Prerendering config files...")
 
 		// render files passed with configs.files property, replacing placeholders with values specified in configs.data property

--- a/templateBuilder_test.go
+++ b/templateBuilder_test.go
@@ -11,6 +11,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("IncludesIngressIfVisibilityIsPrivateAndKindIsDeployment", func(t *testing.T) {
 
 		params := Params{
+			Action:     ActionDeploySimple,
 			Visibility: "private",
 			Kind:       "deployment",
 		}
@@ -24,6 +25,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("IncludesIngressIfVisibilityIsIapAndKindIsDeployment", func(t *testing.T) {
 
 		params := Params{
+			Action:     ActionDeploySimple,
 			Visibility: "iap",
 			Kind:       "deployment",
 		}
@@ -37,6 +39,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("IncludesIngressIfVisibilityIsPublicWhitelistAndKindIsDeployment", func(t *testing.T) {
 
 		params := Params{
+			Action:     ActionDeploySimple,
 			Visibility: "public-whitelist",
 			Kind:       "deployment",
 		}
@@ -50,6 +53,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("DoesNotIncludeIngressIfVisibilityIsPublic", func(t *testing.T) {
 
 		params := Params{
+			Action:     ActionDeploySimple,
 			Visibility: "public",
 		}
 
@@ -62,6 +66,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("IncludesInternalIngressIfOneOrMoreInternalHostsAreSetAndKindIsDeployment", func(t *testing.T) {
 
 		params := Params{
+			Action:        ActionDeploySimple,
 			Kind:          "deployment",
 			InternalHosts: []string{"ci.estafette.internal"},
 		}
@@ -75,6 +80,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("DoesNotIncludeInternalIngressIfNoInternalHostsAreSet", func(t *testing.T) {
 
 		params := Params{
+			Action:        ActionDeploySimple,
 			InternalHosts: []string{},
 		}
 
@@ -87,6 +93,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("IncludesApplicationSecretsIfLengthOfSecretsIsMoreThanZero", func(t *testing.T) {
 
 		params := Params{
+			Action: ActionDeploySimple,
 			Secrets: SecretsParams{
 				Keys: map[string]interface{}{
 					"secret-file-1.json": "c29tZSBzZWNyZXQgdmFsdWU=",
@@ -103,7 +110,9 @@ func TestGetTemplates(t *testing.T) {
 
 	t.Run("DoesNotIncludeApplicationSecretsIfLengthOfSecretsZero", func(t *testing.T) {
 
-		params := Params{}
+		params := Params{
+			Action: ActionDeploySimple,
+		}
 
 		// act
 		templates := getTemplates(params, true)
@@ -114,6 +123,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("AddLocalManifestsIfSetInLocalManifestsParam", func(t *testing.T) {
 
 		params := Params{
+			Action: ActionDeploySimple,
 			Manifests: ManifestsParams{
 				Files: []string{
 					"./gke/another-ingress.yaml",
@@ -130,6 +140,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("OverrideWithLocalManifestsIfSetInLocalManifestsParamWithSameFilename", func(t *testing.T) {
 
 		params := Params{
+			Action: ActionDeploySimple,
 			Manifests: ManifestsParams{
 				Files: []string{
 					"./gke/service.yaml",
@@ -147,7 +158,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("ReturnsEmptyListIfActionIsRollbackCanaray", func(t *testing.T) {
 
 		params := Params{
-			Action: "rollback-canary",
+			Action: ActionRollbackCanary,
 		}
 
 		// act
@@ -159,7 +170,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("ReturnsOnlyHorizontalPodAutoscalerAndPodDisruptionBudgetIfActionIsDeployCanary", func(t *testing.T) {
 
 		params := Params{
-			Action: "deploy-canary",
+			Action: ActionDeployCanary,
 		}
 
 		// act
@@ -172,6 +183,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("DoesNotIncludeCertificateSecretIfCertificateSecretIsSet", func(t *testing.T) {
 
 		params := Params{
+			Action:            ActionDeploySimple,
 			Kind:              "deployment",
 			CertificateSecret: "shared-wildcard-letsencrypt-certificate",
 		}
@@ -185,7 +197,8 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("IncludesCertificateSecretIfCertificateSecretIsNotSet", func(t *testing.T) {
 
 		params := Params{
-			Kind: "deployment",
+			Action: ActionDeploySimple,
+			Kind:   "deployment",
 		}
 
 		// act
@@ -197,6 +210,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("IncludesApigeeIngressIfVisibilityIsApigeeAndKindIsDeployment", func(t *testing.T) {
 
 		params := Params{
+			Action:     ActionDeploySimple,
 			Visibility: "apigee",
 			Kind:       "deployment",
 		}

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -135,7 +135,7 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 	// set tracing service name
 	data.Container.EnvironmentVariables = addEnvironmentVariableIfNotSet(data.Container.EnvironmentVariables, "JAEGER_SERVICE_NAME", params.App)
 
-	if params.Action == "deploy-canary" || params.Action == "diff-canary" {
+	if params.Action == ActionDeployCanary || params.Action == ActionDiffCanary {
 		data.Container.EnvironmentVariables = addEnvironmentVariableIfNotSet(data.Container.EnvironmentVariables, "JAEGER_SAMPLER_TYPE", "probabilistic")
 		data.Container.EnvironmentVariables = addEnvironmentVariableIfNotSet(data.Container.EnvironmentVariables, "JAEGER_SAMPLER_PARAM", "0.1")
 		data.Container.EnvironmentVariables = addEnvironmentVariableIfNotSet(data.Container.EnvironmentVariables, "JAEGER_TAGS", "track=canary")
@@ -240,16 +240,16 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 	}
 
 	switch params.Action {
-	case "deploy-simple",
-		"diff-simple":
+	case ActionDeploySimple,
+		ActionDiffSimple:
 		data.IncludeTrackLabel = false
-	case "deploy-canary",
-		"diff-canary":
+	case ActionDeployCanary,
+		ActionDiffCanary:
 		data.NameWithTrack += "-canary"
 		data.IncludeTrackLabel = true
 		data.TrackLabel = "canary"
-	case "deploy-stable",
-		"diff-stable":
+	case ActionDeployStable,
+		ActionDiffStable:
 		data.NameWithTrack += "-stable"
 		data.IncludeTrackLabel = true
 		data.TrackLabel = "stable"

--- a/templateDataGenerator_test.go
+++ b/templateDataGenerator_test.go
@@ -1472,7 +1472,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-canary",
+			Action: ActionDeployCanary,
 		}
 
 		// act
@@ -1485,7 +1485,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-stable",
+			Action: ActionDeployStable,
 		}
 
 		// act
@@ -1498,7 +1498,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-simple",
+			Action: ActionDeploySimple,
 		}
 
 		// act
@@ -1511,7 +1511,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-simple",
+			Action: ActionDeploySimple,
 		}
 		releaseID := ""
 
@@ -1525,7 +1525,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-simple",
+			Action: ActionDeploySimple,
 		}
 		releaseID := "1"
 
@@ -1539,7 +1539,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-simple",
+			Action: ActionDeploySimple,
 		}
 		triggeredBy := ""
 
@@ -1553,7 +1553,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-simple",
+			Action: ActionDeploySimple,
 		}
 		triggeredBy := "user@estafette.io"
 
@@ -1567,7 +1567,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-simple",
+			Action: ActionDeploySimple,
 		}
 
 		// act
@@ -1580,7 +1580,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-canary",
+			Action: ActionDeployCanary,
 		}
 
 		// act
@@ -1593,7 +1593,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-stable",
+			Action: ActionDeployStable,
 		}
 
 		// act
@@ -1606,7 +1606,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-canary",
+			Action: ActionDeployCanary,
 		}
 
 		// act
@@ -1619,7 +1619,7 @@ func TestGenerateTemplateData(t *testing.T) {
 
 		params := Params{
 			App:    "myapp",
-			Action: "deploy-stable",
+			Action: ActionDeployStable,
 		}
 
 		// act


### PR DESCRIPTION
In order to restart an existing deployment and replace all pods the following actions can be used:

```yaml
actions:
- name: restart-simple
- name: restart-canary
- name: restart-stable
```

Optionally the actions can be hidden from the release badge with

```yaml
actions:
- name: restart-stable
  hideBadge: true
```