### PR TITLE
default disableServiceAccountKeyRotation to true to avoid unintended …

### DIFF
--- a/params.go
+++ b/params.go
@@ -56,7 +56,7 @@ type Params struct {
 
 	EnablePayloadLogging                   bool   `json:"enablePayloadLogging,omitempty" yaml:"enablePayloadLogging,omitempty"`
 	UseGoogleCloudCredentials              bool   `json:"useGoogleCloudCredentials,omitempty" yaml:"useGoogleCloudCredentials,omitempty"`
-	DisableServiceAccountKeyRotation       bool   `json:"disableServiceAccountKeyRotation,omitempty" yaml:"disableServiceAccountKeyRotation,omitempty"`
+	DisableServiceAccountKeyRotation       *bool  `json:"disableServiceAccountKeyRotation,omitempty" yaml:"disableServiceAccountKeyRotation,omitempty"`
 	LegacyGoogleCloudServiceAccountKeyFile string `json:"legacyGoogleCloudServiceAccountKeyFile,omitempty" yaml:"legacyGoogleCloudServiceAccountKeyFile,omitempty"`
 	GoogleCloudCredentialsApp              string `json:"googleCloudCredentialsApp,omitempty" yaml:"googleCloudCredentialsApp,omitempty"`
 	ProbeService                           *bool  `json:"probeService,omitempty" yaml:"probeService,omitempty"`
@@ -236,6 +236,13 @@ func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersio
 	if p.App == "" && appLabel != "" {
 		p.App = appLabel
 	}
+
+	// default DisableServiceAccountKeyRotation to true for avoiding unintended side-effects of key rotation
+	if p.DisableServiceAccountKeyRotation == nil {
+		trueValue := true
+		p.DisableServiceAccountKeyRotation = &trueValue
+	}
+
 	// default GoogleCloudCredentialsApp to App if empty
 	if p.GoogleCloudCredentialsApp == "" {
 		p.GoogleCloudCredentialsApp = p.App
@@ -749,7 +756,7 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 		if p.Visibility == "esp" && !p.UseGoogleCloudCredentials {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property useGoogleCloudCredentials is required; set useGoogleCloudCredentials: true on this stage"))
 		}
-		if p.Visibility == "esp" && !p.DisableServiceAccountKeyRotation {
+		if p.Visibility == "esp" && (p.DisableServiceAccountKeyRotation == nil || !*p.DisableServiceAccountKeyRotation) {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property disableServiceAccountKeyRotation is required; set disableServiceAccountKeyRotation: true on this stage"))
 		}
 		if p.Visibility == "esp" && p.EspOpenAPIYamlPath == "" {

--- a/params_test.go
+++ b/params_test.go
@@ -158,6 +158,30 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, "yourapp", params.App)
 	})
 
+	t.Run("DefaultsDisableServiceAccountKeyRotationToTrueIfEmpty", func(t *testing.T) {
+
+		params := Params{
+			DisableServiceAccountKeyRotation: nil,
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
+
+		assert.Equal(t, true, *params.DisableServiceAccountKeyRotation)
+	})
+
+	t.Run("KeepsDisableServiceAccountKeyRotationIfNotEmpty", func(t *testing.T) {
+
+		params := Params{
+			DisableServiceAccountKeyRotation: &falseValue,
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
+
+		assert.Equal(t, false, *params.DisableServiceAccountKeyRotation)
+	})
+
 	t.Run("DefaultsGoogleCloudCredentialsAppToAppIfEmpty", func(t *testing.T) {
 
 		params := Params{

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -59,12 +59,11 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		RollingUpdateMaxSurge:       params.RollingUpdate.MaxSurge,
 		RollingUpdateMaxUnavailable: params.RollingUpdate.MaxUnavailable,
 
-		PreferPreemptibles:               params.ChaosProof,
-		MountServiceAccountSecret:        params.UseGoogleCloudCredentials || params.LegacyGoogleCloudServiceAccountKeyFile != "",
-		UseLegacyServiceAccountKey:       params.LegacyGoogleCloudServiceAccountKeyFile != "",
-		GoogleCloudCredentialsAppName:    params.GoogleCloudCredentialsApp,
-		GoogleCloudCredentialsLabels:     sanitizeLabels(params.Labels),
-		DisableServiceAccountKeyRotation: params.DisableServiceAccountKeyRotation,
+		PreferPreemptibles:            params.ChaosProof,
+		MountServiceAccountSecret:     params.UseGoogleCloudCredentials || params.LegacyGoogleCloudServiceAccountKeyFile != "",
+		UseLegacyServiceAccountKey:    params.LegacyGoogleCloudServiceAccountKeyFile != "",
+		GoogleCloudCredentialsAppName: params.GoogleCloudCredentialsApp,
+		GoogleCloudCredentialsLabels:  sanitizeLabels(params.Labels),
 
 		PodManagementPolicy: params.PodManagementPolicy,
 		StorageClass:        params.StorageClass,
@@ -116,6 +115,10 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 
 	if params.BackoffLimit != nil {
 		data.BackoffLimit = *params.BackoffLimit
+	}
+
+	if params.DisableServiceAccountKeyRotation != nil {
+		data.DisableServiceAccountKeyRotation = *params.DisableServiceAccountKeyRotation
 	}
 
 	if data.MountServiceAccountSecret {


### PR DESCRIPTION
…side-effects of key rotation

Key rotation causes trouble for new applications where devs aren't aware of the necessity to be able to handle key rotation properly in the application, so better to default it to true.