### PR TITLE
specify 'endpoints' project during ESP deployment

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -294,6 +294,7 @@ stages:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
         credentials: gke-tooling
         visibility: esp
+        espEnpointsProjectID: travix-development
         espConfigID: 2019-04-24r0
         espOpenapiYamlPath: test/openapi.yaml
         container:

--- a/main.go
+++ b/main.go
@@ -533,7 +533,7 @@ func removeIngressIfRequired(ctx context.Context, params Params, templateData Te
 
 func deployGoogleEndpointsServiceIfRequired(ctx context.Context, params Params) {
 	if params.Kind == "deployment" && params.Visibility == "esp" && (params.Action == ActionDeploySimple || params.Action == ActionDeployCanary) {
-		foundation.RunCommandWithArgs(ctx, "gcloud", []string{"endpoints", "services", "deploy", params.EspOpenAPIYamlPath})
+		foundation.RunCommandWithArgs(ctx, "gcloud", []string{"endpoints", "--project", params.EspEnpointsProjectID, "services", "deploy", params.EspOpenAPIYamlPath})
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -533,6 +533,7 @@ func removeIngressIfRequired(ctx context.Context, params Params, templateData Te
 
 func deployGoogleEndpointsServiceIfRequired(ctx context.Context, params Params) {
 	if params.Kind == KindDeployment && params.Visibility == VisibilityESP && (params.Action == ActionDeploySimple || params.Action == ActionDeployCanary) {
+		log.Info().Msgf("Deploying endpoints service, endpoints project:  %v", params.EspEnpointsProjectID)
 		foundation.RunCommandWithArgs(ctx, "gcloud", []string{"endpoints", "--project", params.EspEnpointsProjectID, "services", "deploy", params.EspOpenAPIYamlPath})
 	}
 }

--- a/params.go
+++ b/params.go
@@ -753,7 +753,6 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 			errors = append(errors, fmt.Errorf("StorageMountPath is required for a statefulset; set it via storagemountpath property on this stage"))
 		}
 	}
-
 	// validate params with respect to incoming requests
 	if p.Kind == KindDeployment {
 		if p.Visibility == VisibilityUnknown || (p.Visibility != VisibilityPrivate && p.Visibility != VisibilityPublic && p.Visibility != VisibilityIAP && p.Visibility != VisibilityESP && p.Visibility != VisibilityPublicWhitelist && p.Visibility != VisibilityApigee) {

--- a/params.go
+++ b/params.go
@@ -40,6 +40,7 @@ type Params struct {
 	ContainerNativeLoadBalancing    bool                `json:"containerNativeLoadBalancing,omitempty" yaml:"containerNativeLoadBalancing,omitempty"`
 	IapOauthCredentialsClientID     string              `json:"iapOauthClientID,omitempty" yaml:"iapOauthClientID,omitempty"`
 	IapOauthCredentialsClientSecret string              `json:"iapOauthClientSecret,omitempty" yaml:"iapOauthClientSecret,omitempty"`
+	EspEnpointsProjectID            string              `json:"espEnpointsProjectID,omitempty" yaml:"espEnpointsProjectID,omitempty"`
 	EspConfigID                     string              `json:"espConfigID,omitempty" yaml:"espConfigID,omitempty"`
 	EspOpenAPIYamlPath              string              `json:"espOpenapiYamlPath,omitempty" yaml:"espOpenapiYamlPath,omitempty"`
 	WhitelistedIPS                  []string            `json:"whitelist,omitempty" yaml:"whitelist,omitempty"`
@@ -758,6 +759,9 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 		}
 		if p.Visibility == "esp" && (p.DisableServiceAccountKeyRotation == nil || !*p.DisableServiceAccountKeyRotation) {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property disableServiceAccountKeyRotation is required; set disableServiceAccountKeyRotation: true on this stage"))
+		}
+		if p.Visibility == "esp" && (p.EspEnpointsProjectID == nil) {
+			errors = append(errors, fmt.Errorf("With visibility 'esp' property espEnpointsProjectID is required; provide id of the 'endpoints' project"))
 		}
 		if p.Visibility == "esp" && p.EspOpenAPIYamlPath == "" {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property espOpenapiYamlPath is required; set espOpenapiYamlPath to the path towards openapi.yaml"))

--- a/params.go
+++ b/params.go
@@ -760,7 +760,7 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 		if p.Visibility == "esp" && (p.DisableServiceAccountKeyRotation == nil || !*p.DisableServiceAccountKeyRotation) {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property disableServiceAccountKeyRotation is required; set disableServiceAccountKeyRotation: true on this stage"))
 		}
-		if p.Visibility == "esp" && (p.EspEnpointsProjectID == nil) {
+		if p.Visibility == "esp" && (p.EspEnpointsProjectID == "") {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property espEnpointsProjectID is required; provide id of the 'endpoints' project"))
 		}
 		if p.Visibility == "esp" && p.EspOpenAPIYamlPath == "" {

--- a/params_test.go
+++ b/params_test.go
@@ -116,6 +116,15 @@ var (
 	}
 )
 
+func stringInErrorSlice(a string, list []error) string {
+	for _, b := range list {
+		if b.Error() == a {
+			return a
+		}
+	}
+	return ""
+}
+
 func TestSetDefaults(t *testing.T) {
 
 	t.Run("DefaultsAppToGitNameIfAppParamIsEmptyAndAppLabelIsEmpty", func(t *testing.T) {
@@ -3932,6 +3941,20 @@ func TestValidateRequiredProperties(t *testing.T) {
 
 		assert.True(t, valid)
 		assert.Equal(t, 1, len(warnings))
+	})
+
+	t.Run("ReturnsFalseIfEspEnpointsProjectIDNotSet", func(t *testing.T) {
+
+		params := validParams
+		params.Kind = KindDeployment
+		params.Visibility = VisibilityESP
+		params.EspEnpointsProjectID = ""
+		error_string := "With visibility 'esp' property espEnpointsProjectID is required; provide id of the 'endpoints' project"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+		assert.False(t, valid)
+		assert.Equal(t, error_string, stringInErrorSlice(error_string, errors))
 	})
 }
 


### PR DESCRIPTION
During deployment of ESP make it mandatory to specify project_id of GCP project where service endpoints will be created.
This will allow to keep GKE/application projects separate from central project used for service endpoints.
 I think it make sense to have espEnpointsProjectID as a mandatory setting when esp mode is enabled. To not fall back to active project but make user to provide project_id explicitly - we want to enforce this behaviour everywhere in dev/stg/prd.
I’m afraid if we fall back to active project_id it might be not obvious and people by mistake can create ESP in application projects and then we will have headache of migrating them to centralised endpoints project.