### PR TITLE
render complex envvar as template

### DIFF
--- a/templateData.go
+++ b/templateData.go
@@ -105,6 +105,7 @@ type TemplateData struct {
 	IapOauthCredentialsClientSecret string
 	IsSimpleEnvvarValue             func(interface{}) bool
 	ToYAML                          func(interface{}) string
+	RenderToYAML                    func(v interface{}, data interface{}) string
 	UseCertificateSecret            bool
 	CertificateSecretName           string
 }

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+	"text/template"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -111,6 +113,7 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		// IsSimpleEnvvarValue returns true if a value should be wrapped in 'value: ""', otherwise the interface should be outputted as yaml
 		IsSimpleEnvvarValue: isSimpleEnvvarValue,
 		ToYAML:              toYAML,
+		RenderToYAML:        renderToYAML,
 	}
 
 	if params.BackoffLimit != nil {
@@ -523,4 +526,22 @@ func toYAML(v interface{}) string {
 		return ""
 	}
 	return string(data)
+}
+
+func renderToYAML(v interface{}, data interface{}) string {
+
+	value := toYAML(v)
+
+	tmpl, err := template.New("renderToYAML").Parse(value)
+	if err != nil {
+		return value
+	}
+
+	var renderedTemplate bytes.Buffer
+	err = tmpl.Execute(&renderedTemplate, data)
+	if err != nil {
+		return value
+	}
+
+	return renderedTemplate.String()
 }

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -48,7 +48,7 @@ spec:
               {{- if (call $.IsSimpleEnvvarValue $value) }}
               value: "{{ $value }}"
               {{- else }}
-{{(call $.ToYAML $value) | indent 14}}
+{{(call $.RenderToYAML $value $) | indent 14}}
               {{- end }}
             {{- end }}
             resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         resources:
@@ -206,7 +206,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         volumeMounts:
@@ -284,7 +284,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         {{- end }}
@@ -317,7 +317,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         {{- end }}

--- a/templates/job.yaml
+++ b/templates/job.yaml
@@ -41,7 +41,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         resources:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -72,7 +72,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         resources:
@@ -189,7 +189,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         volumeMounts:
@@ -223,7 +223,7 @@ spec:
           {{- if (call $.IsSimpleEnvvarValue $value) }}
           value: "{{ $value }}"
           {{- else }}
-{{(call $.ToYAML $value) | indent 10}}
+{{(call $.RenderToYAML $value $) | indent 10}}
           {{- end }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
In order to use `secretKeyRef` envvars for canary/stable deployments and resolve to the correct secret this PR replaces placeholders in complex envvars as well, so it can use placeholders like `{{.NameWithTrack}}` in there.