### PR TITLE
add kind: proxy-deployment to offload to other backend

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -390,6 +390,13 @@ stages:
                   fieldPath: metadata.labels['app']
         dryrun: true
 
+      test-kind-proxy-deployment:
+        image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
+        credentials: gke-tooling
+        kind: proxy-deployment
+        proxyBackend: https://mybackend
+        dryrun: true
+
       test-kind-config:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
         credentials: gke-tooling

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -395,6 +395,8 @@ stages:
         credentials: gke-tooling
         kind: proxy-deployment
         proxyBackend: https://mybackend
+        hosts:
+        - gke.estafette.io
         dryrun: true
 
       test-kind-config:

--- a/kind.go
+++ b/kind.go
@@ -5,6 +5,7 @@ type Kind string
 const (
 	KindDeployment         Kind = "deployment"
 	KindHeadlessDeployment Kind = "headless-deployment"
+	KindProxyDeployment    Kind = "proxy-deployment"
 	KindStatefulset        Kind = "statefulset"
 	KindJob                Kind = "job"
 	KindCronJob            Kind = "cronjob"

--- a/params.go
+++ b/params.go
@@ -688,13 +688,13 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 	}
 
 	// validate container params
-	if p.Container.ImageRepository == "" {
+	if p.Container.ImageRepository == "" && p.Kind != KindProxyDeployment {
 		errors = append(errors, fmt.Errorf("Image repository is required; set it via container.repository property on this stage"))
 	}
-	if p.Container.ImageName == "" {
+	if p.Container.ImageName == "" && p.Kind != KindProxyDeployment {
 		errors = append(errors, fmt.Errorf("Image name is required; set it via container.name property on this stage"))
 	}
-	if p.Container.ImageTag == "" {
+	if p.Container.ImageTag == "" && p.Kind != KindProxyDeployment {
 		errors = append(errors, fmt.Errorf("Image tag is required; set it via container.tag property on this stage"))
 	}
 

--- a/params.go
+++ b/params.go
@@ -625,7 +625,7 @@ func (p *Params) initializeSidecarDefaults(sidecar *SidecarParams) {
 		}
 	case SidecarTypeESP:
 		if sidecar.Image == "" {
-			sidecar.Image = "gcr.io/endpoints-release/endpoints-runtime:1.50.0"
+			sidecar.Image = "gcr.io/endpoints-release/endpoints-runtime:1.53.0"
 		}
 	case SidecarTypeCloudSQLProxy:
 		if sidecar.Image == "" {
@@ -772,10 +772,10 @@ func (p *Params) ValidateRequiredProperties() (bool, []error, []string) {
 			errors = append(errors, fmt.Errorf("With visibility 'iap' property iapOauthClientSecret is required; set it via iapOauthClientSecret property on this stage"))
 		}
 
-		if p.Visibility == VisibilityESP && !p.UseGoogleCloudCredentials {
+		if p.Visibility == VisibilityESP && !p.UseGoogleCloudCredentials && p.LegacyGoogleCloudServiceAccountKeyFile == "" {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property useGoogleCloudCredentials is required; set useGoogleCloudCredentials: true on this stage"))
 		}
-		if p.Visibility == VisibilityESP && (p.DisableServiceAccountKeyRotation == nil || !*p.DisableServiceAccountKeyRotation) {
+		if p.Visibility == VisibilityESP && (p.DisableServiceAccountKeyRotation == nil || !*p.DisableServiceAccountKeyRotation) && p.LegacyGoogleCloudServiceAccountKeyFile == "" {
 			errors = append(errors, fmt.Errorf("With visibility 'esp' property disableServiceAccountKeyRotation is required; set disableServiceAccountKeyRotation: true on this stage"))
 		}
 		if p.Visibility == VisibilityESP && (p.EspEndpointsProjectID == "") {

--- a/params.go
+++ b/params.go
@@ -449,8 +449,11 @@ func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersio
 		p.Container.Metrics.Port = p.Container.Port
 	}
 	if p.Container.Metrics.Scrape == nil {
-		trueValue := true
-		p.Container.Metrics.Scrape = &trueValue
+		defaultValue := true
+		if p.Kind == KindProxyDeployment {
+			defaultValue = false
+		}
+		p.Container.Metrics.Scrape = &defaultValue
 	}
 
 	// set lifecycle defaults

--- a/params_test.go
+++ b/params_test.go
@@ -1599,6 +1599,23 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, true, *params.Container.Metrics.Scrape)
 	})
 
+	t.Run("DefaultsMetricsScrapeToFalseIfEmptyAndKindProxyDeployment", func(t *testing.T) {
+
+		params := Params{
+			Kind: KindProxyDeployment,
+			Container: ContainerParams{
+				Metrics: MetricsParams{
+					Scrape: nil,
+				},
+			},
+		}
+
+		// act
+		params.SetDefaults("", "", "", "", "", "", "", map[string]string{})
+
+		assert.Equal(t, false, *params.Container.Metrics.Scrape)
+	})
+
 	t.Run("KeepsMetricsScrapeIfNotEmpty", func(t *testing.T) {
 
 		params := Params{

--- a/params_test.go
+++ b/params_test.go
@@ -3956,6 +3956,32 @@ func TestValidateRequiredProperties(t *testing.T) {
 		assert.False(t, valid)
 		assert.Equal(t, error_string, stringInErrorSlice(error_string, errors))
 	})
+
+	t.Run("ReturnsTrueIfKindIsProxyDeploymentAndProxyBackendIsNotEmpty", func(t *testing.T) {
+
+		params := validParams
+		params.Kind = KindProxyDeployment
+		params.ProxyBackend = "https://backendservice:443"
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.True(t, valid)
+		assert.True(t, len(errors) == 0)
+	})
+
+	t.Run("ReturnsFalseIfKindIsProxyDeploymentAndProxyBackendIsEmpty", func(t *testing.T) {
+
+		params := validParams
+		params.Kind = KindProxyDeployment
+		params.ProxyBackend = ""
+
+		// act
+		valid, errors, _ := params.ValidateRequiredProperties()
+
+		assert.False(t, valid)
+		assert.True(t, len(errors) > 0)
+	})
 }
 
 func TestReplaceSidecarTagsWithDigest(t *testing.T) {

--- a/templateBuilder.go
+++ b/templateBuilder.go
@@ -77,7 +77,8 @@ func getTemplates(params Params, includePodDisruptionBudget bool) []string {
 			templatesToMerge = append(templatesToMerge, "certificate-secret.yaml")
 		}
 
-	case KindDeployment:
+	case KindDeployment,
+		KindProxyDeployment:
 		templatesToMerge = append(templatesToMerge, []string{
 			"namespace.yaml",
 			"service.yaml",
@@ -96,25 +97,25 @@ func getTemplates(params Params, includePodDisruptionBudget bool) []string {
 		}...)
 	}
 
-	if includePodDisruptionBudget && (params.Kind == KindDeployment || params.Kind == KindHeadlessDeployment || params.Kind == KindStatefulset) && (params.Action == ActionDeploySimple || params.Action == ActionDeployStable || params.Action == ActionDiffSimple || params.Action == ActionDiffCanary || params.Action == ActionDiffStable) {
+	if includePodDisruptionBudget && (params.Kind == KindDeployment || params.Kind == KindHeadlessDeployment || params.Kind == KindProxyDeployment || params.Kind == KindStatefulset) && (params.Action == ActionDeploySimple || params.Action == ActionDeployStable || params.Action == ActionDiffSimple || params.Action == ActionDiffCanary || params.Action == ActionDiffStable) {
 		templatesToMerge = append(templatesToMerge, "poddisruptionbudget.yaml")
 	}
-	if (params.Kind == KindDeployment || params.Kind == KindHeadlessDeployment) && params.Autoscale.Enabled != nil && *params.Autoscale.Enabled && params.StrategyType != "Recreate" && (params.Action == ActionDeploySimple || params.Action == ActionDeployStable || params.Action == ActionDiffSimple || params.Action == ActionDiffCanary || params.Action == ActionDiffStable) {
+	if (params.Kind == KindDeployment || params.Kind == KindHeadlessDeployment || params.Kind == KindProxyDeployment) && params.Autoscale.Enabled != nil && *params.Autoscale.Enabled && params.StrategyType != "Recreate" && (params.Action == ActionDeploySimple || params.Action == ActionDeployStable || params.Action == ActionDiffSimple || params.Action == ActionDiffCanary || params.Action == ActionDiffStable) {
 		templatesToMerge = append(templatesToMerge, "horizontalpodautoscaler.yaml")
 	}
-	if (params.Kind == KindDeployment || params.Kind == KindStatefulset) && (params.Visibility == VisibilityPrivate || params.Visibility == VisibilityIAP || params.Visibility == VisibilityPublicWhitelist) {
+	if (params.Kind == KindDeployment || params.Kind == KindProxyDeployment || params.Kind == KindStatefulset) && (params.Visibility == VisibilityPrivate || params.Visibility == VisibilityIAP || params.Visibility == VisibilityPublicWhitelist) {
 		templatesToMerge = append(templatesToMerge, "ingress.yaml")
 	}
 
-	if params.Kind == KindDeployment && params.Visibility == VisibilityApigee {
+	if (params.Kind == KindDeployment || params.Kind == KindProxyDeployment) && params.Visibility == VisibilityApigee {
 		templatesToMerge = append(templatesToMerge, "ingress-apigee.yaml")
 		templatesToMerge = append(templatesToMerge, "ingress.yaml")
 	}
 
-	if (params.Kind == KindDeployment || params.Kind == KindStatefulset) && params.Visibility == VisibilityIAP {
+	if (params.Kind == KindDeployment || params.Kind == KindProxyDeployment || params.Kind == KindStatefulset) && params.Visibility == VisibilityIAP {
 		templatesToMerge = append(templatesToMerge, "backend-config.yaml", "iap-oauth-credentials-secret.yaml")
 	}
-	if (params.Kind == KindDeployment || params.Kind == KindStatefulset) && len(params.InternalHosts) > 0 {
+	if (params.Kind == KindDeployment || params.Kind == KindProxyDeployment || params.Kind == KindStatefulset) && len(params.InternalHosts) > 0 {
 		templatesToMerge = append(templatesToMerge, "ingress-internal.yaml")
 	}
 	if len(params.Secrets.Keys) > 0 {

--- a/templateData.go
+++ b/templateData.go
@@ -95,6 +95,7 @@ type TemplateData struct {
 	NginxAuthTLSSecret                   string
 	NginxAuthTLSVerifyDepth              int
 
+	IncludeApplicationContainer     bool
 	IncludeReplicas                 bool
 	Replicas                        int
 	PodManagementPolicy             string
@@ -108,6 +109,10 @@ type TemplateData struct {
 	RenderToYAML                    func(v interface{}, data interface{}) string
 	UseCertificateSecret            bool
 	CertificateSecretName           string
+
+	OffloadToProto string
+	OffloadToHost  string
+	OffloadToPort  int
 }
 
 // ContainerData has data specific to the application container

--- a/templateDataGenerator_test.go
+++ b/templateDataGenerator_test.go
@@ -2264,4 +2264,128 @@ func TestGenerateTemplateData(t *testing.T) {
 		assert.Equal(t, []string{"google-apigee.com", "travix-apigee.com", "test-app-apigee"}, templateData.ApigeeHosts)
 		assert.Equal(t, "google-apigee.com,travix-apigee.com,test-app-apigee", templateData.ApigeeHostsJoined)
 	})
+
+	t.Run("SetsOffloadToProtoToHttpByDefault", func(t *testing.T) {
+
+		params := Params{}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, "http", templateData.OffloadToProto)
+	})
+
+	t.Run("SetsOffloadToProtoToProtoFromProxyBackendForKindProxyDeployment", func(t *testing.T) {
+
+		params := Params{
+			Kind:         KindProxyDeployment,
+			ProxyBackend: "https://mybackend",
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, "https", templateData.OffloadToProto)
+	})
+
+	t.Run("SetsOffloadToHostTo127Dot0Dot0Dot1ByDefault", func(t *testing.T) {
+
+		params := Params{}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, "127.0.0.1", templateData.OffloadToHost)
+	})
+
+	t.Run("SetsOffloadToHostFromProxyBackendForKindProxyDeployment", func(t *testing.T) {
+
+		params := Params{
+			Kind:         KindProxyDeployment,
+			ProxyBackend: "https://mybackend",
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, "mybackend", templateData.OffloadToHost)
+	})
+
+	t.Run("SetsOffloadToPortToContainerPortByDefault", func(t *testing.T) {
+
+		params := Params{
+			Container: ContainerParams{
+				Port: 5000,
+			},
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, 5000, templateData.OffloadToPort)
+	})
+
+	t.Run("SetsOffloadToPortToPortFromProxyBackendForKindProxyDeployment", func(t *testing.T) {
+
+		params := Params{
+			Kind:         KindProxyDeployment,
+			ProxyBackend: "https://mybackend:5353",
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, 5353, templateData.OffloadToPort)
+	})
+
+	t.Run("SetsOffloadToPortTo80IfProxyBackendHasNoPortAndHttpSchemeForKindProxyDeployment", func(t *testing.T) {
+
+		params := Params{
+			Kind:         KindProxyDeployment,
+			ProxyBackend: "http://mybackend",
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, 80, templateData.OffloadToPort)
+	})
+
+	t.Run("SetsOffloadToPortTo443IfProxyBackendHasNoPortAndHttpsSchemeForKindProxyDeployment", func(t *testing.T) {
+
+		params := Params{
+			Kind:         KindProxyDeployment,
+			ProxyBackend: "https://mybackend",
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, 443, templateData.OffloadToPort)
+	})
+
+	t.Run("SetsIncludeApplicationContainerToTrueByDefault", func(t *testing.T) {
+
+		params := Params{
+			Kind: KindDeployment,
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, true, templateData.IncludeApplicationContainer)
+	})
+
+	t.Run("SetsIncludeApplicationContainerToFalseIfKindIsProxyDeployment", func(t *testing.T) {
+
+		params := Params{
+			Kind:         KindProxyDeployment,
+			ProxyBackend: "https://mybackend",
+		}
+
+		// act
+		templateData := generateTemplateData(params, -1, "github.com", "estafette", "estafette-extension-gke", "master", "02770946ad015b34da9e9980007bf81308c41aec", "", "")
+
+		assert.Equal(t, false, templateData.IncludeApplicationContainer)
+	})
 }

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
 {{(call $.ToYAML .InitContainers) | indent 6}}
       {{- end}}
       containers:
+      {{- if .IncludeApplicationContainer }}
       - name: {{.Name}}
         image: {{.Container.Repository}}/{{.Container.Name}}:{{.Container.Tag}}
         imagePullPolicy: IfNotPresent
@@ -158,6 +159,7 @@ spec:
               - /bin/sleep
               - {{.Container.PreStopSleepSeconds}}s
         {{- end}}
+      {{- end}}
       {{ $deployment := . }}
       {{- range .Sidecars}}
         {{- if eq .Type "openresty" }}
@@ -191,10 +193,12 @@ spec:
               fieldPath: status.hostIP
         - name: "JAEGER_SAMPLER_MANAGER_HOST_PORT"
           value: "http://$(JAEGER_AGENT_HOST):5778/sampling"
+        - name: "OFFLOAD_TO_PROTO"
+          value: "{{$deployment.OffloadToProto}}"
         - name: "OFFLOAD_TO_HOST"
-          value: "127.0.0.1"
+          value: "{{$deployment.OffloadToHost}}"
         - name: "OFFLOAD_TO_PORT"
-          value: "{{$deployment.Container.Port}}"
+          value: "{{$deployment.OffloadToPort}}"
         - name: "SERVICE_NAME"
           value: "{{$deployment.Name}}"
         - name: "NAMESPACE"


### PR DESCRIPTION
In order to for example use `visibility: esp` for another application this can be used to proxy towards that application.

```yaml
kind: proxy-deployment
proxyBackend: https://otherapplication
visibility: esp
...
```

Although there's no main container it still uses some container parameters, for the readiness check amongst others.