### PR TITLE
Testing --record=false option to avoid configMap hitting size limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -270,7 +270,7 @@ func main() {
 			removeIngressIfRequired(ctx, params, templateData, templateData.Name, templateData.Namespace)
 
 			log.Info().Msg("Applying the manifests for real...")
-			foundation.RunCommandWithArgs(ctx, "kubectl", []string{"apply", "-f", "/kubernetes.yaml", "-n", templateData.Namespace})
+			foundation.RunCommandWithArgs(ctx, "kubectl", []string{"apply", "--record=false", "-f", "/kubernetes.yaml", "-n", templateData.Namespace})
 
 			if params.Kind == KindDeployment || params.Kind == KindHeadlessDeployment {
 				log.Info().Msg("Waiting for the deployment to finish...")


### PR DESCRIPTION
Estafette-ci-config is failing when applying the new credentials config. Apparently it's hitting a size limit in the annotations field that stores the command being executed. One of the ideas to deal with it is adding the --record=false option to disable the annotation.