### PR TITLE
set pod labels similar to what helm uses, to unify alerting

### DIFF
--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -272,6 +272,11 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 		data.TrackLabel = "stable"
 	}
 
+	// set some additional labels similar to helm charts in order to unify alerting and dashboards
+	data.PodLabels["app.kubernetes.io/name"] = data.Name
+	data.PodLabels["app.kubernetes.io/instance"] = data.NameWithTrack
+	data.PodLabels["app.kubernetes.io/managed-by"] = "estafette"
+
 	data.ConfigmapFiles = params.Configs.RenderedFileContent
 
 	data.ManifestData = map[string]interface{}{}

--- a/templateDataGenerator.go
+++ b/templateDataGenerator.go
@@ -275,6 +275,7 @@ func generateTemplateData(params Params, currentReplicas int, gitSource, gitOwne
 	// set some additional labels similar to helm charts in order to unify alerting and dashboards
 	data.PodLabels["app.kubernetes.io/name"] = data.Name
 	data.PodLabels["app.kubernetes.io/instance"] = data.NameWithTrack
+	data.PodLabels["app.kubernetes.io/version"] = sanitizeLabel(params.BuildVersion)
 	data.PodLabels["app.kubernetes.io/managed-by"] = "estafette"
 
 	data.ConfigmapFiles = params.Configs.RenderedFileContent


### PR DESCRIPTION
Setting them just on pods for now, since `app.kubernetes.io/instance` will be dependent on whether you're deploying a canary or stable release, which would cause shared components like the `service` to be updated for both.