### PR TITLE
Use mounted credential file

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -72,7 +72,7 @@ stages:
     parallelStages:
       test-with-defaults:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         action: deploy-simple
         kind: deployment
         app: gke
@@ -285,7 +285,7 @@ stages:
 
       test-minimal-alpha-version:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         container:
           repository: extensions
         hosts:
@@ -294,7 +294,7 @@ stages:
 
       test-os-windows:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         os: windows
         container:
           repository: extensions
@@ -304,7 +304,7 @@ stages:
 
       test-visibility-esp:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         visibility: esp
         espEndpointsProjectID: some-project-id
         espConfigID: 2019-04-24r0
@@ -319,7 +319,7 @@ stages:
 
       test-kind-job:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         kind: job
         tolerations:
         - key: "test-key"
@@ -343,7 +343,7 @@ stages:
 
       test-kind-cronjob:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         kind: cronjob
         schedule: "*/5 * * * *"
         concurrencypolicy: Forbid
@@ -369,7 +369,7 @@ stages:
 
       test-kind-statefulset:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         kind: statefulset
         podManagementpolicy: OrderedReady
         storageclass: fast
@@ -392,7 +392,7 @@ stages:
 
       test-kind-headless-deployment:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         kind: headless-deployment
         strategytype: Recreate
         tolerations:
@@ -417,7 +417,7 @@ stages:
 
       test-kind-config:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         kind: config
         app: gke
         namespace: estafette
@@ -443,7 +443,7 @@ stages:
 
       test-action-deploy-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         action: deploy-canary
         container:
           repository: extensions
@@ -453,7 +453,7 @@ stages:
 
       test-action-deploy-stable:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         action: deploy-stable
         container:
           repository: extensions
@@ -463,13 +463,13 @@ stages:
 
       test-action-rollback-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         action: rollback-canary
         dryrun: true
 
       test-action-diff-simple:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         action: diff-simple
         container:
           repository: extensions
@@ -479,7 +479,7 @@ stages:
 
       test-action-diff-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         action: diff-canary
         container:
           repository: extensions
@@ -489,7 +489,7 @@ stages:
 
       test-action-diff-stable:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         action: diff-stable
         container:
           repository: extensions
@@ -499,7 +499,7 @@ stages:
 
       test-legacy-gcp-service-account:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-estafette
+        credentials: gke-tooling-common
         container:
           repository: extensions
         hosts:

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -290,6 +290,8 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-os-windows:
@@ -300,6 +302,8 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-visibility-esp:
@@ -315,6 +319,8 @@ stages:
         disableServiceAccountKeyRotation: true
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-kind-job:
@@ -339,6 +345,10 @@ stages:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.labels['app']
+        hosts:
+        - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-kind-cronjob:
@@ -365,6 +375,10 @@ stages:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.labels['app']
+        hosts:
+        - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-kind-statefulset:
@@ -388,6 +402,8 @@ stages:
                   fieldPath: metadata.labels['app']
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-kind-headless-deployment:
@@ -504,6 +520,8 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.internal.estafette.io
         dryrun: true
         legacyGoogleCloudServiceAccountKeyFile: YWJjCg==
 

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -72,7 +72,7 @@ stages:
     parallelStages:
       test-with-defaults:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         action: deploy-simple
         kind: deployment
         app: gke
@@ -285,7 +285,7 @@ stages:
 
       test-minimal-alpha-version:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         container:
           repository: extensions
         hosts:
@@ -294,7 +294,7 @@ stages:
 
       test-os-windows:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         os: windows
         container:
           repository: extensions
@@ -304,7 +304,7 @@ stages:
 
       test-visibility-esp:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         visibility: esp
         espEndpointsProjectID: some-project-id
         espConfigID: 2019-04-24r0
@@ -319,7 +319,7 @@ stages:
 
       test-kind-job:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         kind: job
         tolerations:
         - key: "test-key"
@@ -343,7 +343,7 @@ stages:
 
       test-kind-cronjob:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         kind: cronjob
         schedule: "*/5 * * * *"
         concurrencypolicy: Forbid
@@ -369,7 +369,7 @@ stages:
 
       test-kind-statefulset:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         kind: statefulset
         podManagementpolicy: OrderedReady
         storageclass: fast
@@ -392,7 +392,7 @@ stages:
 
       test-kind-headless-deployment:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         kind: headless-deployment
         strategytype: Recreate
         tolerations:
@@ -417,7 +417,7 @@ stages:
 
       test-kind-config:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         kind: config
         app: gke
         namespace: estafette
@@ -443,7 +443,7 @@ stages:
 
       test-action-deploy-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         action: deploy-canary
         container:
           repository: extensions
@@ -453,7 +453,7 @@ stages:
 
       test-action-deploy-stable:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         action: deploy-stable
         container:
           repository: extensions
@@ -463,13 +463,13 @@ stages:
 
       test-action-rollback-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         action: rollback-canary
         dryrun: true
 
       test-action-diff-simple:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         action: diff-simple
         container:
           repository: extensions
@@ -479,7 +479,7 @@ stages:
 
       test-action-diff-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         action: diff-canary
         container:
           repository: extensions
@@ -489,7 +489,7 @@ stages:
 
       test-action-diff-stable:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         action: diff-stable
         container:
           repository: extensions
@@ -499,7 +499,7 @@ stages:
 
       test-legacy-gcp-service-account:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling
+        credentials: gke-tooling-estafette
         container:
           repository: extensions
         hosts:

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -72,7 +72,7 @@ stages:
     parallelStages:
       test-with-defaults:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         action: deploy-simple
         kind: deployment
         app: gke
@@ -285,7 +285,7 @@ stages:
 
       test-minimal-alpha-version:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         container:
           repository: extensions
         hosts:
@@ -294,7 +294,7 @@ stages:
 
       test-os-windows:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         os: windows
         container:
           repository: extensions
@@ -304,7 +304,7 @@ stages:
 
       test-visibility-esp:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         visibility: esp
         espEndpointsProjectID: some-project-id
         espConfigID: 2019-04-24r0
@@ -319,7 +319,7 @@ stages:
 
       test-kind-job:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         kind: job
         tolerations:
         - key: "test-key"
@@ -343,7 +343,7 @@ stages:
 
       test-kind-cronjob:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         kind: cronjob
         schedule: "*/5 * * * *"
         concurrencypolicy: Forbid
@@ -369,7 +369,7 @@ stages:
 
       test-kind-statefulset:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         kind: statefulset
         podManagementpolicy: OrderedReady
         storageclass: fast
@@ -392,7 +392,7 @@ stages:
 
       test-kind-headless-deployment:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         kind: headless-deployment
         strategytype: Recreate
         tolerations:
@@ -417,7 +417,7 @@ stages:
 
       test-kind-config:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         kind: config
         app: gke
         namespace: estafette
@@ -443,7 +443,7 @@ stages:
 
       test-action-deploy-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         action: deploy-canary
         container:
           repository: extensions
@@ -453,7 +453,7 @@ stages:
 
       test-action-deploy-stable:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         action: deploy-stable
         container:
           repository: extensions
@@ -463,13 +463,13 @@ stages:
 
       test-action-rollback-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         action: rollback-canary
         dryrun: true
 
       test-action-diff-simple:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         action: diff-simple
         container:
           repository: extensions
@@ -479,7 +479,7 @@ stages:
 
       test-action-diff-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         action: diff-canary
         container:
           repository: extensions
@@ -489,7 +489,7 @@ stages:
 
       test-action-diff-stable:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         action: diff-stable
         container:
           repository: extensions
@@ -499,7 +499,7 @@ stages:
 
       test-legacy-gcp-service-account:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
-        credentials: gke-tooling-common
+        credentials: gke-dev-common
         container:
           repository: extensions
         hosts:

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -429,6 +429,10 @@ stages:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.labels['app']
+        hosts:
+        - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-kind-config:
@@ -455,6 +459,10 @@ stages:
               enemies=aliens
               lives=3
           mountpath: /configs
+        hosts:
+        - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-action-deploy-canary:
@@ -465,6 +473,8 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-action-deploy-stable:
@@ -475,12 +485,18 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-action-rollback-canary:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
         credentials: gke-dev-common
         action: rollback-canary
+        hosts:
+        - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-action-diff-simple:
@@ -491,6 +507,8 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-action-diff-canary:
@@ -501,6 +519,8 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-action-diff-stable:
@@ -511,6 +531,8 @@ stages:
           repository: extensions
         hosts:
         - gke.estafette.io
+        internalhosts:
+        - gke.estafette.internal
         dryrun: true
 
       test-legacy-gcp-service-account:

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ var (
 	// flags
 	paramsJSON      = kingpin.Flag("params", "Extension parameters, created from custom properties.").Envar("ESTAFETTE_EXTENSION_CUSTOM_PROPERTIES").Required().String()
 	paramsYAML      = kingpin.Flag("params-yaml", "Extension parameters, created from custom properties.").Envar("ESTAFETTE_EXTENSION_CUSTOM_PROPERTIES_YAML").Required().String()
-	credentialsJSON = kingpin.Flag("credentials", "GKE credentials configured at service level, passed in to this trusted extension.").Envar("ESTAFETTE_CREDENTIALS_KUBERNETES_ENGINE").String()
 	credentialsPath = kingpin.Flag("credentials-path", "Path to GKE credentials configured at service level, passed in to this trusted extension.").Default("/credentials/kubernetes_engine.json").String()
 
 	// optional flags
@@ -119,11 +118,6 @@ func main() {
 			log.Warn().Str("data", string(credentialsFileContent)).Msgf("Found 0 credentials in file %v", *credentialsPath)
 		}
 		log.Debug().Msgf("Read %v credentials", len(credentials))
-	} else {
-		err = json.Unmarshal([]byte(*credentialsJSON), &credentials)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed unmarshalling injected credentials")
-		}
 	}
 
 	log.Info().Msgf("Checking if credential %v exists...", credentialsParam.Credentials)

--- a/main.go
+++ b/main.go
@@ -112,6 +112,10 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed unmarshalling injected credentials")
 		}
+		if len(credentials) == 0 {
+			log.Warn().Str("data", string(credentialsFileContent)).Msgf("Found 0 credentials in file %v", *credentialsPath)
+		}
+		log.Debug().Msgf("Read %v credentials", len(credentials))
 	} else {
 		err = json.Unmarshal([]byte(*credentialsJSON), &credentials)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func main() {
 			log.Fatal().Msgf("Failed reading credential file at path %v.", *credentialsPath)
 		}
 		*credentialsJSON = string(credentialsFileContent)
+		log.Debug().Msgf("Read string of length %v from file at path %v", len(string(credentialsFileContent)), *credentialsPath)
 	}
 
 	err = json.Unmarshal([]byte(*credentialsJSON), &credentials)

--- a/main.go
+++ b/main.go
@@ -108,13 +108,15 @@ func main() {
 		if err != nil {
 			log.Fatal().Msgf("Failed reading credential file at path %v.", *credentialsPath)
 		}
-		*credentialsJSON = string(credentialsFileContent)
-		log.Debug().Msgf("Read string of length %v from file at path %v", len(string(credentialsFileContent)), *credentialsPath)
-	}
-
-	err = json.Unmarshal([]byte(*credentialsJSON), &credentials)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed unmarshalling injected credentials")
+		err = json.Unmarshal(credentialsFileContent, &credentials)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed unmarshalling injected credentials")
+		}
+	} else {
+		err = json.Unmarshal([]byte(*credentialsJSON), &credentials)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed unmarshalling injected credentials")
+		}
 	}
 
 	log.Info().Msgf("Checking if credential %v exists...", credentialsParam.Credentials)

--- a/main.go
+++ b/main.go
@@ -102,6 +102,9 @@ func main() {
 	var credentials []GKECredentials
 
 	// use mounted credential file if present instead of relying on an envvar
+	if runtime.GOOS == "windows" {
+		*credentialsPath = "C:" + *credentialsPath
+	}
 	if foundation.FileExists(*credentialsPath) {
 		log.Info().Msgf("Reading credentials from file at path %v...", *credentialsPath)
 		credentialsFileContent, err := ioutil.ReadFile(*credentialsPath)

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func main() {
 
 	// use mounted credential file if present instead of relying on an envvar
 	if foundation.FileExists(*credentialsPath) {
+		log.Info().Msgf("Reading credentials from file at path %v...", *credentialsPath)
 		credentialsFileContent, err := ioutil.ReadFile(*credentialsPath)
 		if err != nil {
 			log.Fatal().Msgf("Failed reading credential file at path %v.", *credentialsPath)


### PR DESCRIPTION
Temporary hybrid situation where credentials are mounted as a file but also still injected as environment variable. When all extensions support the mounted file the envvar approach will be dropped.