### PR TITLE
Adjust the deploymentname we use when getting the replica count

### DIFF
--- a/main.go
+++ b/main.go
@@ -592,12 +592,12 @@ func getExistingNumberOfReplicas(ctx context.Context, params Params) int {
 	if params.Kind == KindDeployment || params.Kind == KindHeadlessDeployment {
 		deploymentName := ""
 		if params.Action == ActionDeploySimple || params.Action == ActionDiffSimple {
-			deploymentName = params.App + "-stable"
-		} else if params.Action == ActionDeployStable || params.Action == ActionDiffStable {
 			deploymentName = params.App
+		} else if params.Action == ActionDeployStable || params.Action == ActionDiffStable {
+			deploymentName = params.App + "-stable"
 		}
 		if deploymentName != "" {
-			replicas, err := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"get", "deploy", deploymentName, "-n", params.Namespace, "-o=jsonpath={.spec.replicas}"})
+			replicas, err := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"get", "deploy", deploymentName, "-n", params.Namespace, "-o=\"jsonpath={.spec.replicas}\""})
 			if err != nil {
 				log.Info().Msgf("Failed retrieving replicas for %v: %v ignoring setting replicas since there's no switch for deployment type...", deploymentName, err)
 				return -1


### PR DESCRIPTION
I tried doing a deployment where I specified the replica count explicitly with
```
    replicas: 1
    autoscale:
      enabled: false
```
And setting the replica count didn't work, this was the error in the logs:
```
> kubectl get deploy v3-logging-format-stable -n apps -o=jsonpath={.spec.replicas}
Failed retrieving replicas for v3-logging-format-stable: exit status 1 ignoring setting replicas since there's no switch for deployment type...
```
One issue is that this app is not using canary deployments, so the name of the deployment is `v3-logging-format`, and not `v3-logging-format-stable`. (And for me on Windows the output format was also not working, I needed to enclose the `jsonpath={.spec.replicas}` part in double quotes to get it to work. But this might be just a Windows thing.)

Looking at the logic, it seems to me that that `if` statement is the other way around than how it is supposed to be, could you check if I'm correct?