### PR TITLE
change ingress class name to use spec instead of annotation

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# ncurses-libs vulnerability resolved in 6.3_p20211120-r1 regarding violation in convert_strings
+CVE-2022-29458

--- a/services/extension/service.go
+++ b/services/extension/service.go
@@ -408,6 +408,7 @@ func (s *service) removeIngressIfRequired(ctx context.Context, params api.Params
 					// delete the ingress so all related load balancers, etc get deleted
 					log.Info().Msg("Deleting ingress so the gce ingress controller removes the related load balancer...")
 					foundation.RunCommandWithArgs(ctx, "kubectl", []string{"delete", "ingress", name, "-n", namespace, "--ignore-not-found=true"})
+					foundation.RunCommandWithArgs(ctx, "kubectl", []string{"wait", "--for=delete", "ingress/" + name, "-n", namespace, "--timeout=3s"})
 				} else {
 					log.Info().Msgf("Ingress %v already has kubernetes.io/ingress.class: %v annotation, no need to delete the ingress", name, ingressClass)
 				}
@@ -422,6 +423,7 @@ func (s *service) removeIngressIfRequired(ctx context.Context, params api.Params
 					// delete the ingress so all related nginx ingress config gets deleted
 					log.Info().Msg("Deleting ingress so the nginx ingress controller removes related config...")
 					foundation.RunCommandWithArgs(ctx, "kubectl", []string{"delete", "ingress", name, "-n", namespace, "--ignore-not-found=true"})
+					foundation.RunCommandWithArgs(ctx, "kubectl", []string{"wait", "--for=delete", "ingress/" + name, "-n", namespace, "--timeout=3s"})
 				} else {
 					log.Info().Msgf("Ingress %v already has ingressClassName: %v already set, no need to delete the ingress", name, ingressClass)
 				}

--- a/services/extension/service.go
+++ b/services/extension/service.go
@@ -419,7 +419,7 @@ func (s *service) removeIngressIfRequired(ctx context.Context, params api.Params
 			// check if ingress exists and has kubernetes.io/ingress.class: gce, then delete it to ensure there's no nginx ingress annotations lingering around
 			ingressClass, err := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"get", "ing", name, "-n", namespace, "-o=go-template={{ .spec.ingressClassName }}"})
 			if err == nil {
-				if ingressClass == "nginx" {
+				if ingressClass == "nginx-office" {
 					// delete the ingress so all related nginx ingress config gets deleted
 					log.Info().Msg("Deleting ingress so the nginx ingress controller removes related config...")
 					foundation.RunCommandWithArgs(ctx, "kubectl", []string{"delete", "ingress", name, "-n", namespace, "--ignore-not-found=true"})

--- a/services/extension/service.go
+++ b/services/extension/service.go
@@ -416,17 +416,17 @@ func (s *service) removeIngressIfRequired(ctx context.Context, params api.Params
 			}
 		} else if templateData.UseGCEIngress {
 			// check if ingress exists and has kubernetes.io/ingress.class: gce, then delete it to ensure there's no nginx ingress annotations lingering around
-			ingressClass, err := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"get", "ing", name, "-n", namespace, "-o=go-template={{index .metadata.annotations \"kubernetes.io/ingress.class\"}}"})
+			ingressClass, err := foundation.GetCommandWithArgsOutput(ctx, "kubectl", []string{"get", "ing", name, "-n", namespace, "-o=go-template={{ .spec.ingressClassName }}"})
 			if err == nil {
 				if ingressClass == "nginx" {
 					// delete the ingress so all related nginx ingress config gets deleted
 					log.Info().Msg("Deleting ingress so the nginx ingress controller removes related config...")
 					foundation.RunCommandWithArgs(ctx, "kubectl", []string{"delete", "ingress", name, "-n", namespace, "--ignore-not-found=true"})
 				} else {
-					log.Info().Msgf("Ingress %v already has kubernetes.io/ingress.class: %v annotation, no need to delete the ingress", name, ingressClass)
+					log.Info().Msgf("Ingress %v already has ingressClassName: %v already set, no need to delete the ingress", name, ingressClass)
 				}
 			} else {
-				log.Info().Msgf("Ingress %v or kubernetes.io/ingress.class annotation doesn't exist, no need to delete the ingress: %v", name, err)
+				log.Info().Msgf("Ingress %v or ingressClassName doesn't exist, no need to delete the ingress: %v", name, err)
 			}
 		}
 	}


### PR DESCRIPTION
As a follow-up to #83 , the logic for removing unused ingresses has to be adjusted.  

This is the output when conditions apply:
```
...
> kubectl get ing example -n apps -o=go-template={{ .spec.ingressClassName }}
Deleting ingress so the nginx ingress controller removes related config...
...
```