### PR TITLE
add KEEPALIVE_TIMEOUT parameter for openresty sidecar

### DIFF
--- a/api/params.go
+++ b/api/params.go
@@ -169,6 +169,7 @@ type AutoscaleSafetyParams struct {
 type RequestParams struct {
 	IngressBackendProtocol string `json:"ingressbackendprotocol,omitempty" yaml:"ingressbackendprotocol,omitempty"`
 	Timeout                string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	KeepaliveTimeout       string `json:"keepaliveTimeout,omitempty" yaml:"keepaliveTimeout,omitempty"`
 	MaxBodySize            string `json:"maxbodysize,omitempty" yaml:"maxbodysize,omitempty"`
 	ProxyBufferSize        string `json:"proxybuffersize,omitempty" yaml:"proxybuffersize,omitempty"`
 	ProxyBuffersNumber     int    `json:"proxybuffersnumber,omitempty" yaml:"proxybuffersnumber,omitempty"`
@@ -449,6 +450,9 @@ func (p *Params) SetDefaults(gitSource, gitOwner, gitName, appLabel, buildVersio
 	}
 	if p.Request.Timeout == "" {
 		p.Request.Timeout = "60s"
+	}
+	if p.Request.KeepaliveTimeout == "" {
+		p.Request.KeepaliveTimeout = "20s"
 	}
 	if p.Request.MaxBodySize == "" {
 		p.Request.MaxBodySize = "128m"

--- a/services/generator/service.go
+++ b/services/generator/service.go
@@ -582,6 +582,7 @@ func (s *service) BuildSidecar(sidecar *api.SidecarParams, params api.Params) ap
 	}
 
 	if sidecar.Type == api.SidecarTypeOpenresty {
+		builtSidecar.EnvironmentVariables = s.AddEnvironmentVariableIfNotSet(builtSidecar.EnvironmentVariables, "KEEPALIVE_TIMEOUT", params.Request.KeepaliveTimeout)
 		builtSidecar.EnvironmentVariables = s.AddEnvironmentVariableIfNotSet(builtSidecar.EnvironmentVariables, "SEND_TIMEOUT", params.Request.Timeout)
 		builtSidecar.EnvironmentVariables = s.AddEnvironmentVariableIfNotSet(builtSidecar.EnvironmentVariables, "CLIENT_BODY_TIMEOUT", params.Request.Timeout)
 		builtSidecar.EnvironmentVariables = s.AddEnvironmentVariableIfNotSet(builtSidecar.EnvironmentVariables, "CLIENT_HEADER_TIMEOUT", params.Request.Timeout)


### PR DESCRIPTION
Let extension controls default values and support user customization for the KEEPALIVE_TIMEOUT of openresty sidecar.