### PR TITLE
delete removing workload identity annotation by gke extension

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -26,7 +26,7 @@ stages:
     image: extensions/docker:dev
     action: build
     inline: |
-      FROM alpine:3.16
+      FROM alpine:3.17.0
 
       ENV KUBECTL_VERSION="v1.24.3"
 

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -13,7 +13,7 @@ version:
 
 stages:
   build:
-    image: golang:1.17-alpine
+    image: golang:1.19-alpine
     env:
       CGO_ENABLED: 0
       GOOS: linux
@@ -660,7 +660,7 @@ stages:
         internalhosts:
         - gke.estafette.internal
 
-        test-legacy-gcp-service-account:
+      test-legacy-gcp-service-account:
         image: extensions/gke:${ESTAFETTE_BUILD_VERSION}
         credentials: gke-dev-common
         container:

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -40,7 +40,7 @@ stages:
           && chmod +x /usr/bin/kubectl \
           && kubectl version --client
 
-      FROM google/cloud-sdk:406.0.0-alpine
+      FROM google/cloud-sdk:410.0.0-alpine
 
       RUN apk add --update --upgrade --no-cache \
           && rm -rf /var/cache/apk/* 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/estafette/estafette-extension-gke
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2

--- a/go.sum
+++ b/go.sum
@@ -410,7 +410,6 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
 golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -477,10 +476,8 @@ golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -494,9 +491,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -554,8 +548,8 @@ golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/services/extension/service.go
+++ b/services/extension/service.go
@@ -190,7 +190,6 @@ func (s *service) Run(ctx context.Context, credential *api.GKECredentials, relea
 				s.deleteSecretsForParamsChange(ctx, params, templateData.NameWithTrack, templateData.Namespace)
 				s.deleteServiceAccountSecretForParamsChange(ctx, params, templateData.GoogleCloudCredentialsAppName, templateData.Namespace)
 				s.deleteIngressForVisibilityChange(ctx, templateData, templateData.Name, templateData.Namespace)
-				s.removeWorkloadIdentityAnnotationForParamsChange(ctx, params, templateData, templateData.Name, templateData.Namespace)
 				s.removeEstafetteCloudflareAnnotations(ctx, templateData, templateData.Name, templateData.Namespace)
 				s.removeBackendConfigAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
 				s.removeNegAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
@@ -216,7 +215,6 @@ func (s *service) Run(ctx context.Context, credential *api.GKECredentials, relea
 				s.deleteSecretsForParamsChange(ctx, params, templateData.Name, templateData.Namespace)
 				s.deleteServiceAccountSecretForParamsChange(ctx, params, templateData.GoogleCloudCredentialsAppName, templateData.Namespace)
 				s.deleteIngressForVisibilityChange(ctx, templateData, templateData.Name, templateData.Namespace)
-				s.removeWorkloadIdentityAnnotationForParamsChange(ctx, params, templateData, templateData.Name, templateData.Namespace)
 				s.removeEstafetteCloudflareAnnotations(ctx, templateData, templateData.Name, templateData.Namespace)
 				s.removeBackendConfigAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
 				s.removeNegAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
@@ -239,7 +237,6 @@ func (s *service) Run(ctx context.Context, credential *api.GKECredentials, relea
 				s.deleteConfigsForParamsChange(ctx, params, templateData.NameWithTrack, templateData.Namespace)
 				s.deleteSecretsForParamsChange(ctx, params, templateData.NameWithTrack, templateData.Namespace)
 				s.deleteServiceAccountSecretForParamsChange(ctx, params, templateData.GoogleCloudCredentialsAppName, templateData.Namespace)
-				s.removeWorkloadIdentityAnnotationForParamsChange(ctx, params, templateData, templateData.Name, templateData.Namespace)
 				s.deleteHorizontalPodAutoscaler(ctx, params, templateData.NameWithTrack, templateData.Namespace)
 				break
 			case api.ActionRollbackCanary:
@@ -260,7 +257,6 @@ func (s *service) Run(ctx context.Context, credential *api.GKECredentials, relea
 				s.deleteConfigsForParamsChange(ctx, params, templateData.Name, templateData.Namespace)
 				s.deleteSecretsForParamsChange(ctx, params, templateData.Name, templateData.Namespace)
 				s.deleteServiceAccountSecretForParamsChange(ctx, params, templateData.GoogleCloudCredentialsAppName, templateData.Namespace)
-				s.removeWorkloadIdentityAnnotationForParamsChange(ctx, params, templateData, templateData.Name, templateData.Namespace)
 				s.deleteHorizontalPodAutoscaler(ctx, params, templateData.Name, templateData.Namespace)
 				break
 			}
@@ -270,7 +266,6 @@ func (s *service) Run(ctx context.Context, credential *api.GKECredentials, relea
 			s.deleteSecretsForParamsChange(ctx, params, templateData.Name, templateData.Namespace)
 			s.deleteServiceAccountSecretForParamsChange(ctx, params, templateData.GoogleCloudCredentialsAppName, templateData.Namespace)
 			s.deleteIngressForVisibilityChange(ctx, templateData, templateData.Name, templateData.Namespace)
-			s.removeWorkloadIdentityAnnotationForParamsChange(ctx, params, templateData, templateData.Name, templateData.Namespace)
 			s.removeEstafetteCloudflareAnnotations(ctx, templateData, templateData.Name, templateData.Namespace)
 			s.removeBackendConfigAnnotation(ctx, templateData, templateData.Name, templateData.Namespace)
 			s.deleteBackendConfigAndIAPOauthSecret(ctx, templateData, templateData.Name, templateData.Namespace)
@@ -343,13 +338,6 @@ func (s *service) deleteServiceAccountSecretForParamsChange(ctx context.Context,
 	if !params.UseGoogleCloudCredentials && params.LegacyGoogleCloudServiceAccountKeyFile == "" {
 		log.Info().Msg("Deleting service account secret if it exists, because no use of service account is specified...")
 		foundation.RunCommandWithArgs(ctx, "kubectl", []string{"delete", "secret", fmt.Sprintf("%v-gcp-service-account", name), "-n", namespace, "--ignore-not-found=true"})
-	}
-}
-
-func (s *service) removeWorkloadIdentityAnnotationForParamsChange(ctx context.Context, params api.Params, templateData api.TemplateData, name, namespace string) {
-	if !*params.WorkloadIdentity {
-		log.Info().Msg("Removing iam.gke.io/gcp-service-account annotations on the serviceaccount if it exists")
-		foundation.RunCommandWithArgs(ctx, "kubectl", []string{"annotate", "serviceaccount", name, "-n", namespace, "iam.gke.io/gcp-service-account-"})
 	}
 }
 


### PR DESCRIPTION
- Updated Golang version.
- (Workaround until we have the best tool from deployment and gcp-service-account controller) Remove the logic from the gke-deployment on removing the workload identity annotation, removing the annotation might have an issue with creating it again as the state annotation created from the controller.